### PR TITLE
Add IPv6 support and introduce new updater ddns.fm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # UDDNS
+
 UDDNS - Universal (or Ultimate) Dynamic DNS updater
 
 ## How to use
+
 ### Obtaining the program
+
 You can either:
 
 `go install github.com/we11adam/uddns@latest`
 
 or download the binary for you platform directly from the [releases page](https://github.com/we11adam/uddns/releases/)
 
-
 ### Configuration file
-Ceate a `uddns.yaml` file as one the following: `./uddns.yaml`, `~/.config/uddns.yaml`, 
+
+Ceate a `uddns.yaml` file as one the following: `./uddns.yaml`, `~/.config/uddns.yaml`,
 `/etc/uddns.yaml`. UDDNS will try to read them in order. Additionally, you can specify the configuration file path with the `UDDNS_CONFIG` environment variable.
 The file should look like this:
 
@@ -23,13 +26,16 @@ providers:
     password: "" # RouterOS user password
   ip_service:
     - ifconfig.me # External service to get IP address
+# If you use IP routing rules for specific traffic, ensure the domain used by ip_service is excluded.
 
 updaters:
   cloudflare:
     email: "user@exmaple.com" # Cloudflare account email
     apikey: fd25bdc03a4c17450aa4327aa37de4573270f # Cloudflare API key
     domain: ddns.yourdomain.com # Domain to update
-
+  # ddnsfm: # Use ddns.fm as the updater
+  #   key: bgw99xiio5ewbphb
+  #   domain: uddns.dyn.la
 notifiers:
   telegram:
     chat_id: -1001234567890 # Telegram chat ID
@@ -38,6 +44,7 @@ notifiers:
 ```
 
 Where:
+
 - `providers` is a list of providers that UDDNS can use to obtain the current public IP address. Currently supported providers are:
   - `routeros`: Get IP address from a Mikrotik RouterOS device
     - `endpoint`: The RouterOS API endpoint
@@ -57,6 +64,9 @@ Where:
   - `duckdns`:
     - `token`: DuckDNS token
     - `domain`: Domain to update, excluding the `duckdns.org` part.
+  - `ddnsfm`:
+    - `key`: ddns.fm DDNS key
+    - `domain`: Domain to update.
 - `notifiers` is a list of notifiers that UDDNS can use to notify the user of the IP address change. Currently supported notifiers are:
   - `telegram`:
     - `token`: Telegram bot token
@@ -64,13 +74,15 @@ Where:
     - `proxy`: Proxy URL to use for Telegram API requests if you are behind a (great) firewall. Optional.
 
 ### Running
+
 Run the binary as the following. It will update the DNS record with the current public IP address with a default interval of 30 seconds, which can be overriden with the `UDDNS_INTERVAL` environment variable. The format for specifying the interval is flexible, allowing values such as `60s`, `5m`, `1h`, etc.
+
 ```shell
 nohup ./uddns > uddns.log 2>&1 &
 ```
 
-
 ## Roadmap
+
 - [ ] Add more providers
 - [ ] Add more updaters
 - [ ] Add granular configuration options
@@ -81,12 +93,10 @@ nohup ./uddns > uddns.log 2>&1 &
 - [ ] Add Daemon mode
 - [ ] Add systemd service file
 
-
-
 ## Contributing
+
 Pull requests are very welcome! For major changes, please open an issue first to discuss what you would like to change.
 
 ## License
+
 MIT
-
-

--- a/notifier/telegram/telegram.go
+++ b/notifier/telegram/telegram.go
@@ -2,6 +2,7 @@ package telegram
 
 import (
 	"errors"
+
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/viper"
 	"github.com/we11adam/uddns/notifier"

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,11 +2,17 @@ package provider
 
 import (
 	"errors"
+
 	"github.com/spf13/viper"
 )
 
+type IpResult struct {
+	IPv4 string
+	IPv6 string
+}
+
 type Provider interface {
-	Ip() (string, error)
+	GetIPs() (*IpResult, error)
 }
 
 type constructor func(v *viper.Viper) (Provider, error)

--- a/updater/cloudflare/cloudflare.go
+++ b/updater/cloudflare/cloudflare.go
@@ -123,6 +123,7 @@ func (c *Cloudflare) updateDNSRecord(ctx context.Context, recordType, ip string)
 		_, err := c.client.UpdateDNSRecord(ctx, cloudflare.ZoneIdentifier(c.zoneID), updateParams)
 		if err != nil {
 			slog.Error("[CloudFlare] failed to update DNS record:", "error", err, "type", recordType)
+			delete(c.recordIDs, recordType)
 			return err
 		}
 		slog.Info("[CloudFlare] DNS record updated successfully", "type", recordType, "ip", ip)
@@ -133,6 +134,7 @@ func (c *Cloudflare) updateDNSRecord(ctx context.Context, recordType, ip string)
 	dnsRecords, _, err := c.client.ListDNSRecords(ctx, cloudflare.ZoneIdentifier(c.zoneID), params)
 	if err != nil {
 		slog.Error("[CloudFlare] failed to list DNS records:", "error", err, "type", recordType)
+		c.zoneID = ""
 		return err
 	}
 
@@ -151,6 +153,7 @@ func (c *Cloudflare) updateDNSRecord(ctx context.Context, recordType, ip string)
 		_, err := c.client.UpdateDNSRecord(ctx, cloudflare.ZoneIdentifier(c.zoneID), updateParams)
 		if err != nil {
 			slog.Error("[CloudFlare] failed to update DNS record:", "error", err, "type", recordType)
+			delete(c.recordIDs, recordType)
 			return err
 		}
 		slog.Info("[CloudFlare] DNS record updated successfully", "type", recordType, "ip", ip)

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -2,11 +2,13 @@ package updater
 
 import (
 	"errors"
+
 	"github.com/spf13/viper"
+	"github.com/we11adam/uddns/provider"
 )
 
 type Updater interface {
-	Update(ip string) error
+	Update(ips *provider.IpResult) error
 }
 
 type constructor func(v *viper.Viper) (Updater, error)


### PR DESCRIPTION
1. **Network Interface and RouterOS Updaters**
   - Enhanced to concurrently fetch IPv4 and IPv6 addresses using system commands.

2. **IP Service**
   - Utilizes both TCP4 and TCP6 protocols to simultaneously retrieve IPv4 and IPv6 addresses.

3. **Cloudflare Updater**
   - Concurrent modifications to both A and AAAA records are now possible.
   - `zoneID` and `recordID` are stored in variables for efficient reuse in subsequent DNS updates.

4. **IPv6 Support and New Updater**
   - Extended IPv6 support to other updaters.
   - Introduced a new updater, `ddns.fm`.
   - All code has been automatically formatted using the gofmt plugin.

   **To Do:**
   - Customize the user agent for HTTP requests, specifying it as `uddns/1.0.1`.