### PR TITLE
feat: Expose reason to notifier

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -296,13 +296,13 @@ func (a *App) runJob(ctx context.Context, job *Job) {
 	)
 
 	if ipv4NotificationNeeded {
-		if a.notify(ctx, "ip_change", job, notifier.Notification{Message: jobNotificationMessage(job, fmt.Sprintf("IPv4 address changed to %s", ipResult.IPv4))}) {
+		if a.notify(ctx, job, notifier.Notification{Message: jobNotificationMessage(job, fmt.Sprintf("IPv4 address changed to %s", ipResult.IPv4)), Reason: notifier.ReasonIPChange}) {
 			job.lastNotifiedIPv4 = ipResult.IPv4
 		}
 	}
 
 	if ipv6NotificationNeeded {
-		if a.notify(ctx, "ip_change", job, notifier.Notification{Message: jobNotificationMessage(job, fmt.Sprintf("IPv6 address changed to %s", ipResult.IPv6))}) {
+		if a.notify(ctx, job, notifier.Notification{Message: jobNotificationMessage(job, fmt.Sprintf("IPv6 address changed to %s", ipResult.IPv6)), Reason: notifier.ReasonIPChange}) {
 			job.lastNotifiedIPv6 = ipResult.IPv6
 		}
 	}
@@ -330,8 +330,8 @@ func (a *App) runJob(ctx context.Context, job *Job) {
 				"error", err,
 			)...,
 		)
-		failureNotification := notifier.Notification{Message: jobNotificationMessage(job, fmt.Sprintf("DNS update failed for %s: %s", notificationIPSummary(ipResult), err))}
-		if failureNotification.Message != job.lastNotifiedUpdateFailure && a.notify(ctx, "update_failure", job, failureNotification) {
+		failureNotification := notifier.Notification{Message: jobNotificationMessage(job, fmt.Sprintf("DNS update failed for %s: %s", notificationIPSummary(ipResult), err)), Reason: notifier.ReasonUpdateFailure}
+		if failureNotification.Message != job.lastNotifiedUpdateFailure && a.notify(ctx, job, failureNotification) {
 			job.lastNotifiedUpdateFailure = failureNotification.Message
 		}
 		return
@@ -354,7 +354,7 @@ func (a *App) runJob(ctx context.Context, job *Job) {
 			"ipv6", ipResult.IPv6,
 		)...,
 	)
-	a.notify(ctx, "update_success", job, notifier.Notification{Message: jobNotificationMessage(job, fmt.Sprintf("DNS records updated for %s", notificationIPSummary(ipResult)))})
+	a.notify(ctx, job, notifier.Notification{Message: jobNotificationMessage(job, fmt.Sprintf("DNS records updated for %s", notificationIPSummary(ipResult))), Reason: notifier.ReasonUpdateSuccess})
 }
 
 func isBackoffFailure(status string) bool {
@@ -548,13 +548,13 @@ func (job *Job) logAttrs(args ...any) []any {
 	return append(attrs, args...)
 }
 
-func (a *App) notify(ctx context.Context, reason string, job *Job, notification notifier.Notification) bool {
+func (a *App) notify(ctx context.Context, job *Job, notification notifier.Notification) bool {
 	if err := a.notifier.Notify(ctx, notification); err != nil {
 		slog.Error(
 			"failed to send notification",
 			job.logAttrs(
 				"notifier", a.notifierName,
-				"reason", reason,
+				"reason", notification.Reason,
 				"error", err,
 			)...,
 		)

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -6,9 +6,18 @@ import (
 	"github.com/we11adam/uddns/internal/registry"
 )
 
+type Reason string
+
+const (
+	ReasonIPChange      Reason = "ip_change"
+	ReasonUpdateSuccess Reason = "update_success"
+	ReasonUpdateFailure Reason = "update_failure"
+)
+
 type Notification struct {
 	Title   string
 	Message string
+	Reason  Reason
 }
 
 type Notifier interface {


### PR DESCRIPTION
Exposing the reason enables notifier to handle the different cases differently. For example the follow up Discord notifier (#13 ) uses it to determine the message sidebar color.