### PR TITLE
refactor: different things

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -61,12 +61,10 @@ type Job struct {
 type jobStatus string
 
 const (
-	jobStatusIPChange      jobStatus = "ip_change"
 	jobStatusOK            jobStatus = "ok"
 	jobStatusProviderError jobStatus = "provider_error"
 	jobStatusUnchanged     jobStatus = "unchanged"
 	jobStatusUpdaterError  jobStatus = "updater_error"
-	jobStatusUpdateSuccess jobStatus = "update_success"
 	jobStatusVerifyError   jobStatus = "verify_error"
 )
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -97,6 +97,7 @@ func (p *blockingProvider) GetIPs(ctx context.Context, _ provider.FamilyRequest)
 }
 
 func TestRunOnceUpdatesDNSWhenIPChanges(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordingUpdater{}
 	n := &recordingNotifier{}
@@ -130,6 +131,7 @@ func TestRunOnceUpdatesDNSWhenIPChanges(t *testing.T) {
 }
 
 func TestNewAppUsesNoopForNilNotifier(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordingUpdater{}
 	job := NewJob("default", "test-provider", p, "test-updater", u, "", "", AllFamilies(), VerifyOff)
@@ -146,6 +148,7 @@ func TestNewAppUsesNoopForNilNotifier(t *testing.T) {
 }
 
 func TestRunOnceSkipsUnchangedIP(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordingUpdater{}
 	n := &recordingNotifier{}
@@ -163,6 +166,7 @@ func TestRunOnceSkipsUnchangedIP(t *testing.T) {
 }
 
 func TestRunOncePreservesCachedFamilyWhenProviderReturnsPartialResult(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10", IPv6: "2001:db8::1"}}
 	u := &recordingUpdater{}
 	n := &recordingNotifier{}
@@ -204,6 +208,7 @@ func TestRunOncePreservesCachedFamilyWhenProviderReturnsPartialResult(t *testing
 }
 
 func TestRunOnceDoesNotAdvanceLastIPWhenUpdateFails(t *testing.T) {
+	t.Parallel()
 	updateErr := errors.New("update failed")
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordingUpdater{err: updateErr}
@@ -230,6 +235,7 @@ func TestRunOnceDoesNotAdvanceLastIPWhenUpdateFails(t *testing.T) {
 }
 
 func TestRunOnceDeduplicatesRepeatedUpdateFailures(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordingUpdater{err: errors.New("update failed")}
 	n := &recordingNotifier{}
@@ -257,6 +263,7 @@ func TestRunOnceDeduplicatesRepeatedUpdateFailures(t *testing.T) {
 }
 
 func TestRunOnceNotifiesWhenUpdateErrorChanges(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordingUpdater{err: errors.New("first error")}
 	n := &recordingNotifier{}
@@ -282,6 +289,7 @@ func TestRunOnceNotifiesWhenUpdateErrorChanges(t *testing.T) {
 }
 
 func TestRunOnceSuccessfulUpdateClearsFailureDeduplication(t *testing.T) {
+	t.Parallel()
 	updateErr := errors.New("update failed")
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordReadingUpdater{current: &provider.IpResult{IPv4: "192.0.2.9"}}
@@ -313,6 +321,7 @@ func TestRunOnceSuccessfulUpdateClearsFailureDeduplication(t *testing.T) {
 }
 
 func TestRunOnceRetriesIPChangeNotificationThatWasNotDelivered(t *testing.T) {
+	t.Parallel()
 	notifyErr := errors.New("notification failed")
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordingUpdater{}
@@ -337,6 +346,7 @@ func TestRunOnceRetriesIPChangeNotificationThatWasNotDelivered(t *testing.T) {
 }
 
 func TestRunOnceRetriesUpdateFailureNotificationThatWasNotDelivered(t *testing.T) {
+	t.Parallel()
 	notifyErr := errors.New("notification failed")
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordingUpdater{err: errors.New("update failed")}
@@ -362,6 +372,7 @@ func TestRunOnceRetriesUpdateFailureNotificationThatWasNotDelivered(t *testing.T
 }
 
 func TestRunOnceSkipsUpdateWhenProviderFails(t *testing.T) {
+	t.Parallel()
 	providerErr := errors.New("provider failed")
 	p := &staticProvider{err: providerErr}
 	u := &recordingUpdater{}
@@ -379,6 +390,7 @@ func TestRunOnceSkipsUpdateWhenProviderFails(t *testing.T) {
 }
 
 func TestRunOnceSkipsUpdateWhenProviderReturnsInvalidIP(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "not-an-ip"}}
 	u := &recordingUpdater{}
 	n := &recordingNotifier{}
@@ -395,6 +407,7 @@ func TestRunOnceSkipsUpdateWhenProviderReturnsInvalidIP(t *testing.T) {
 }
 
 func TestRunReturnsWhenContextIsCanceled(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordingUpdater{}
 	n := &recordingNotifier{}
@@ -410,6 +423,7 @@ func TestRunReturnsWhenContextIsCanceled(t *testing.T) {
 }
 
 func TestRunCancelsInFlightProvider(t *testing.T) {
+	t.Parallel()
 	p := &blockingProvider{started: make(chan struct{})}
 	u := &recordingUpdater{}
 	n := &recordingNotifier{}
@@ -439,6 +453,7 @@ func TestRunCancelsInFlightProvider(t *testing.T) {
 }
 
 func TestRunOnceFiltersRequestedFamilies(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10", IPv6: "not-an-ip"}}
 	u := &recordingUpdater{}
 	n := &recordingNotifier{}
@@ -458,6 +473,7 @@ func TestRunOnceFiltersRequestedFamilies(t *testing.T) {
 }
 
 func TestRunOnceRequestsOnlyIPv6(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "not-an-ip", IPv6: "2001:db8::1"}}
 	u := &recordingUpdater{}
 	n := &recordingNotifier{}
@@ -477,6 +493,7 @@ func TestRunOnceRequestsOnlyIPv6(t *testing.T) {
 }
 
 func TestRunOncePrefixesNotificationsForNamedJobs(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordingUpdater{}
 	n := &recordingNotifier{}
@@ -494,6 +511,7 @@ func TestRunOncePrefixesNotificationsForNamedJobs(t *testing.T) {
 }
 
 func TestRunOnceUpdatesWhenCurrentRecordDrifts(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordReadingUpdater{current: &provider.IpResult{IPv4: "192.0.2.9"}}
 	n := &recordingNotifier{}
@@ -513,6 +531,7 @@ func TestRunOnceUpdatesWhenCurrentRecordDrifts(t *testing.T) {
 }
 
 func TestRunOnceAutoVerifyDoesNotPollEveryInterval(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordReadingUpdater{current: &provider.IpResult{IPv4: "192.0.2.10"}}
 	job := NewJob("default", "test-provider", p, "test-updater", u, "", "", AllFamilies(), VerifyAuto)
@@ -532,6 +551,7 @@ func TestRunOnceAutoVerifyDoesNotPollEveryInterval(t *testing.T) {
 }
 
 func TestRunOnceAutoVerifyPollsWhenPeriodExpires(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordReadingUpdater{current: &provider.IpResult{IPv4: "192.0.2.10"}}
 	job := NewJob("default", "test-provider", p, "test-updater", u, "", "", AllFamilies(), VerifyAuto)
@@ -557,6 +577,7 @@ func TestRunOnceAutoVerifyPollsWhenPeriodExpires(t *testing.T) {
 }
 
 func TestRunOnceAutoVerifyPollsEarlyWhenProviderIPChanges(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordReadingUpdater{current: &provider.IpResult{IPv4: "192.0.2.10"}}
 	job := NewJob("default", "test-provider", p, "test-updater", u, "", "", AllFamilies(), VerifyAuto)
@@ -578,6 +599,7 @@ func TestRunOnceAutoVerifyPollsEarlyWhenProviderIPChanges(t *testing.T) {
 }
 
 func TestRunOnceStrictVerifyPollsEveryInterval(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordReadingUpdater{current: &provider.IpResult{IPv4: "192.0.2.10"}}
 	job := NewJob("default", "test-provider", p, "test-updater", u, "", "", AllFamilies(), VerifyUpdaterAPI)
@@ -596,6 +618,7 @@ func TestRunOnceStrictVerifyPollsEveryInterval(t *testing.T) {
 }
 
 func TestRunOnceStrictVerifyRequestsOnlyConfiguredFamilies(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordReadingUpdater{
 		read: func(request provider.FamilyRequest) (*provider.IpResult, error) {
@@ -622,6 +645,7 @@ func TestRunOnceStrictVerifyRequestsOnlyConfiguredFamilies(t *testing.T) {
 }
 
 func TestRunOnceAutoVerifyFailureRetriesWithoutAdvancingPeriod(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordReadingUpdater{err: errors.New("verify failed")}
 	job := NewJob("default", "test-provider", p, "test-updater", u, "", "", AllFamilies(), VerifyAuto)
@@ -647,6 +671,7 @@ func TestRunOnceAutoVerifyFailureRetriesWithoutAdvancingPeriod(t *testing.T) {
 }
 
 func TestRunOnceInitializesAppliedIPWhenCurrentRecordMatches(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		verify VerifyMode
@@ -657,6 +682,7 @@ func TestRunOnceInitializesAppliedIPWhenCurrentRecordMatches(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 			u := &recordReadingUpdater{current: &provider.IpResult{IPv4: "192.0.2.10"}}
 			n := &recordingNotifier{}
@@ -679,6 +705,7 @@ func TestRunOnceInitializesAppliedIPWhenCurrentRecordMatches(t *testing.T) {
 }
 
 func TestRunOnceCanonicalizesCurrentIPv6BeforeComparison(t *testing.T) {
+	t.Parallel()
 	const expandedIPv6 = "2001:0DB8:0000:0000:0000:0000:0000:0001"
 	p := &staticProvider{result: &provider.IpResult{IPv6: "2001:db8::1"}}
 	current := &provider.IpResult{IPv6: expandedIPv6}
@@ -700,6 +727,7 @@ func TestRunOnceCanonicalizesCurrentIPv6BeforeComparison(t *testing.T) {
 }
 
 func TestRunOnceStrictVerifyRejectsInvalidCurrentRecord(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordReadingUpdater{current: &provider.IpResult{IPv4: "192.0.2.999"}}
 	job := NewJob("default", "test-provider", p, "test-updater", u, "home.example.com", "example.com", Families{IPv4: true}, VerifyUpdaterAPI)
@@ -716,6 +744,7 @@ func TestRunOnceStrictVerifyRejectsInvalidCurrentRecord(t *testing.T) {
 }
 
 func TestRunOnceInitialCurrentSingleFamilyDriftTriggersUpdate(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10", IPv6: "2001:db8::1"}}
 	u := &recordReadingUpdater{current: &provider.IpResult{IPv4: "192.0.2.10", IPv6: "2001:db8::2"}}
 	n := &recordingNotifier{}
@@ -733,6 +762,7 @@ func TestRunOnceInitialCurrentSingleFamilyDriftTriggersUpdate(t *testing.T) {
 }
 
 func TestRunOnceInitialEmptyCurrentRecordTriggersUpdate(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordReadingUpdater{current: &provider.IpResult{}}
 	n := &recordingNotifier{}
@@ -750,6 +780,7 @@ func TestRunOnceInitialEmptyCurrentRecordTriggersUpdate(t *testing.T) {
 }
 
 func TestRunOnceAutoUpdatesChangedIPWhenRecordReadFails(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordReadingUpdater{err: errors.New("verify failed")}
 	n := &recordingNotifier{}
@@ -772,6 +803,7 @@ func TestRunOnceAutoUpdatesChangedIPWhenRecordReadFails(t *testing.T) {
 }
 
 func TestRunOnceAutoSkipsUnchangedIPWhenRecordReadFails(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordReadingUpdater{err: errors.New("verify failed")}
 	n := &recordingNotifier{}
@@ -794,6 +826,7 @@ func TestRunOnceAutoSkipsUnchangedIPWhenRecordReadFails(t *testing.T) {
 }
 
 func TestRunOnceStrictVerifyBlocksChangedIPWhenRecordReadFails(t *testing.T) {
+	t.Parallel()
 	p := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	u := &recordReadingUpdater{err: errors.New("verify failed")}
 	n := &recordingNotifier{}
@@ -816,6 +849,7 @@ func TestRunOnceStrictVerifyBlocksChangedIPWhenRecordReadFails(t *testing.T) {
 }
 
 func TestCappedExponentialBackoffGrowsAndCaps(t *testing.T) {
+	t.Parallel()
 	base := 10 * time.Second
 	max := time.Minute
 	tests := []struct {
@@ -837,6 +871,7 @@ func TestCappedExponentialBackoffGrowsAndCaps(t *testing.T) {
 }
 
 func TestCappedExponentialBackoffAppliesEqualJitter(t *testing.T) {
+	t.Parallel()
 	base := 10 * time.Second
 	tests := []struct {
 		jitter float64
@@ -857,6 +892,7 @@ func TestCappedExponentialBackoffAppliesEqualJitter(t *testing.T) {
 }
 
 func TestRunOnceBacksOffFailureStatuses(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		job  func() Job
@@ -889,6 +925,7 @@ func TestRunOnceBacksOffFailureStatuses(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			now := time.Unix(1_700_000_000, 0)
 			clock := &fakeClock{now: now}
 			a := NewApp([]Job{tt.job()}, "test-notifier", &recordingNotifier{}, time.Second)
@@ -908,6 +945,7 @@ func TestRunOnceBacksOffFailureStatuses(t *testing.T) {
 }
 
 func TestRunOnceBackoffDoesNotBlockOtherJobs(t *testing.T) {
+	t.Parallel()
 	failingProvider := &staticProvider{err: errors.New("provider failed")}
 	healthyProvider := &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}
 	jobs := []Job{
@@ -932,6 +970,7 @@ func TestRunOnceBackoffDoesNotBlockOtherJobs(t *testing.T) {
 }
 
 func TestRunOnceSuccessAndUnchangedResetBackoff(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		lastIPv4 string
@@ -942,6 +981,7 @@ func TestRunOnceSuccessAndUnchangedResetBackoff(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			clock := &fakeClock{now: time.Unix(1_700_000_000, 0)}
 			job := NewJob(tt.name, "test-provider", &staticProvider{result: &provider.IpResult{IPv4: "192.0.2.10"}}, "test-updater", &recordingUpdater{}, "", "", AllFamilies(), VerifyOff)
 			job.lastAppliedIPv4 = tt.lastIPv4

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -238,7 +238,7 @@ func TestRunOnceDeduplicatesRepeatedUpdateFailures(t *testing.T) {
 	a.clock = clock
 	a.jitter = func() float64 { return 1 }
 
-	for attempt := 0; attempt < 3; attempt++ {
+	for attempt := range 3 {
 		a.runOnce(context.Background())
 		if attempt < 2 {
 			clock.now = a.jobs[0].retryAfter

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,7 +69,7 @@ func validateFilePermissions(path string, info os.FileInfo) error {
 	}
 
 	permissions := info.Mode().Perm()
-	if permissions&0077 == 0 {
+	if permissions&0o077 == 0 {
 		return nil
 	}
 	if isSystemdCredential(path, info) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,7 +12,7 @@ func TestFindFileUsesProvidedReadablePath(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "uddns.yaml")
-	if err := os.WriteFile(path, []byte("providers: {}\n"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("providers: {}\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -27,7 +27,7 @@ func TestFindFileUsesProvidedReadablePath(t *testing.T) {
 
 func TestFindFileRejectsUnreadableProvidedPath(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "uddns.yaml"), []byte("providers: {}\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "uddns.yaml"), []byte("providers: {}\n"), 0o644); err != nil {
 		t.Fatalf("write fallback config: %v", err)
 	}
 	t.Chdir(dir)
@@ -40,7 +40,7 @@ func TestFindFileRejectsUnreadableProvidedPath(t *testing.T) {
 
 func TestFindFileRejectsUnreadableEnvironmentPath(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "uddns.yaml"), []byte("providers: {}\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "uddns.yaml"), []byte("providers: {}\n"), 0o644); err != nil {
 		t.Fatalf("write fallback config: %v", err)
 	}
 	t.Chdir(dir)
@@ -58,7 +58,7 @@ func TestLoadRejectsConfigExposedToOtherUsers(t *testing.T) {
 	}
 
 	path := filepath.Join(t.TempDir(), "uddns.yaml")
-	if err := os.WriteFile(path, []byte("providers: {}\n"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("providers: {}\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -74,7 +74,7 @@ func TestLoadRejectsOrdinaryGroupReadableConfig(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "uddns.yaml")
-	if err := os.WriteFile(path, []byte("providers: {}\n"), 0440); err != nil {
+	if err := os.WriteFile(path, []byte("providers: {}\n"), 0o440); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	t.Setenv("CREDENTIALS_DIRECTORY", dir)
@@ -235,7 +235,7 @@ func writeConfigFile(t *testing.T, content string) string {
 	t.Helper()
 
 	path := filepath.Join(t.TempDir(), "uddns.yaml")
-	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	return path

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestFindFileUsesProvidedReadablePath(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "uddns.yaml")
 	if err := os.WriteFile(path, []byte("providers: {}\n"), 0644); err != nil {
@@ -51,6 +52,7 @@ func TestFindFileRejectsUnreadableEnvironmentPath(t *testing.T) {
 }
 
 func TestLoadRejectsConfigExposedToOtherUsers(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows does not expose Unix permission bits")
 	}
@@ -173,6 +175,7 @@ func TestIntervalAcceptsAllowedBoundaries(t *testing.T) {
 }
 
 func TestJobsParsesConfiguredJobs(t *testing.T) {
+	t.Parallel()
 	path := writeConfigFile(t, `
 jobs:
   - name: home
@@ -201,6 +204,7 @@ jobs:
 }
 
 func TestWithOverridesAppliesNestedValues(t *testing.T) {
+	t.Parallel()
 	path := writeConfigFile(t, `
 updaters:
   duckdns:

--- a/internal/config/systemd_credential.go
+++ b/internal/config/systemd_credential.go
@@ -6,7 +6,7 @@ import (
 )
 
 func hasSystemdCredentialMode(mode os.FileMode) bool {
-	return mode == 0440
+	return mode == 0o440
 }
 
 func isDirectSystemdCredentialPath(path, credentialsDir string) bool {

--- a/internal/config/systemd_credential_linux.go
+++ b/internal/config/systemd_credential_linux.go
@@ -42,7 +42,7 @@ func isTrustedCredentialDirectory(path string) bool {
 			return false
 		}
 		stat, ok := info.Sys().(*syscall.Stat_t)
-		if !ok || stat.Uid != 0 || stat.Gid != 0 || info.Mode().Perm()&0022 != 0 {
+		if !ok || stat.Uid != 0 || stat.Gid != 0 || info.Mode().Perm()&0o022 != 0 {
 			return false
 		}
 		if filepath.Dir(dir) == dir {

--- a/internal/config/systemd_credential_test.go
+++ b/internal/config/systemd_credential_test.go
@@ -14,12 +14,12 @@ func TestHasSystemdCredentialMode(t *testing.T) {
 		mode os.FileMode
 		want bool
 	}{
-		{name: "systemd ACL projection", mode: 0440, want: true},
-		{name: "ordinary private config", mode: 0600},
-		{name: "group writable", mode: 0460},
-		{name: "other readable", mode: 0444},
-		{name: "setuid", mode: os.ModeSetuid | 0440},
-		{name: "directory", mode: os.ModeDir | 0440},
+		{name: "systemd ACL projection", mode: 0o440, want: true},
+		{name: "ordinary private config", mode: 0o600},
+		{name: "group writable", mode: 0o460},
+		{name: "other readable", mode: 0o444},
+		{name: "setuid", mode: os.ModeSetuid | 0o440},
+		{name: "directory", mode: os.ModeDir | 0o440},
 	}
 
 	for _, tt := range tests {
@@ -108,7 +108,7 @@ func TestIsSameRegularFileRejectsSymlinkAndReplacement(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	original := filepath.Join(dir, "original.yaml")
-	if err := os.WriteFile(original, []byte("providers: {}\n"), 0600); err != nil {
+	if err := os.WriteFile(original, []byte("providers: {}\n"), 0o600); err != nil {
 		t.Fatalf("write original: %v", err)
 	}
 
@@ -135,7 +135,7 @@ func TestIsSameRegularFileRejectsSymlinkAndReplacement(t *testing.T) {
 	}
 
 	replacement := filepath.Join(dir, "replacement.yaml")
-	if err := os.WriteFile(replacement, []byte("providers: {}\n"), 0600); err != nil {
+	if err := os.WriteFile(replacement, []byte("providers: {}\n"), 0o600); err != nil {
 		t.Fatalf("write replacement: %v", err)
 	}
 	if err := os.Rename(replacement, original); err != nil {

--- a/internal/config/systemd_credential_test.go
+++ b/internal/config/systemd_credential_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestHasSystemdCredentialMode(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		mode os.FileMode
@@ -23,6 +24,7 @@ func TestHasSystemdCredentialMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := hasSystemdCredentialMode(tt.mode); got != tt.want {
 				t.Fatalf("hasSystemdCredentialMode(%v) = %v, want %v", tt.mode, got, tt.want)
 			}
@@ -31,6 +33,7 @@ func TestHasSystemdCredentialMode(t *testing.T) {
 }
 
 func TestIsDirectSystemdCredentialPath(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("systemd credential paths are Linux paths")
 	}
@@ -92,6 +95,7 @@ func TestIsDirectSystemdCredentialPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := isDirectSystemdCredentialPath(tt.path, tt.credentialsDir); got != tt.want {
 				t.Fatalf("isDirectSystemdCredentialPath(%q, %q) = %v, want %v",
 					tt.path, tt.credentialsDir, got, tt.want)
@@ -101,6 +105,7 @@ func TestIsDirectSystemdCredentialPath(t *testing.T) {
 }
 
 func TestIsSameRegularFileRejectsSymlinkAndReplacement(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	original := filepath.Join(dir, "original.yaml")
 	if err := os.WriteFile(original, []byte("providers: {}\n"), 0600); err != nil {
@@ -142,6 +147,7 @@ func TestIsSameRegularFileRejectsSymlinkAndReplacement(t *testing.T) {
 }
 
 func TestLstatDirectoryRejectsSymlink(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	if _, ok := lstatDirectory(dir); !ok {
 		t.Fatal("expected a real directory to be accepted")

--- a/internal/dnsname/dnsname.go
+++ b/internal/dnsname/dnsname.go
@@ -1,6 +1,7 @@
 package dnsname
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -11,7 +12,7 @@ func Normalize(name string) (string, error) {
 	name = strings.ToLower(strings.TrimSpace(name))
 	name = strings.TrimSuffix(name, ".")
 	if name == "" {
-		return "", fmt.Errorf("DNS name is empty")
+		return "", errors.New("DNS name is empty")
 	}
 	if len(name) > 253 {
 		return "", fmt.Errorf("DNS name is too long: %s", name)
@@ -71,7 +72,7 @@ func splitRecordWithZone(record, zone string) (string, string, error) {
 
 func validateLabel(label string) error {
 	if label == "" {
-		return fmt.Errorf("empty label")
+		return errors.New("empty label")
 	}
 	if len(label) > 63 {
 		return fmt.Errorf("label %q is too long", label)

--- a/internal/dnsname/dnsname.go
+++ b/internal/dnsname/dnsname.go
@@ -18,8 +18,8 @@ func Normalize(name string) (string, error) {
 		return "", fmt.Errorf("DNS name is too long: %s", name)
 	}
 
-	labels := strings.Split(name, ".")
-	for _, label := range labels {
+	labels := strings.SplitSeq(name, ".")
+	for label := range labels {
 		if err := validateLabel(label); err != nil {
 			return "", fmt.Errorf("invalid DNS name %q: %w", name, err)
 		}

--- a/internal/dnsname/dnsname_test.go
+++ b/internal/dnsname/dnsname_test.go
@@ -3,6 +3,7 @@ package dnsname
 import "testing"
 
 func TestSplitRecord(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		recordName string
@@ -28,6 +29,7 @@ func TestSplitRecord(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			zone, rr, err := SplitRecord(tt.recordName, tt.zoneName)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("expected wantErr=%v, got err=%v", tt.wantErr, err)

--- a/internal/httpbody/httpbody_test.go
+++ b/internal/httpbody/httpbody_test.go
@@ -17,6 +17,7 @@ func (r *trackingReadCloser) Close() error {
 }
 
 func TestLimitBoundsReadsAndForwardsClose(t *testing.T) {
+	t.Parallel()
 	body := &trackingReadCloser{Reader: strings.NewReader("123456789")}
 	limited := Limit(body, 4)
 

--- a/internal/proxyurl/proxyurl.go
+++ b/internal/proxyurl/proxyurl.go
@@ -1,7 +1,7 @@
 package proxyurl
 
 import (
-	"fmt"
+	"errors"
 	"net/url"
 	"strings"
 )
@@ -11,21 +11,21 @@ import (
 func Parse(rawURL string) (*url.URL, error) {
 	proxyURL, err := url.Parse(rawURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid proxy URL syntax")
+		return nil, errors.New("invalid proxy URL syntax")
 	}
 
 	proxyURL.Scheme = strings.ToLower(proxyURL.Scheme)
 	if proxyURL.Scheme != "http" && proxyURL.Scheme != "https" {
-		return nil, fmt.Errorf("proxy URL scheme must be http or https")
+		return nil, errors.New("proxy URL scheme must be http or https")
 	}
 	if !proxyURL.IsAbs() || proxyURL.Opaque != "" || proxyURL.Hostname() == "" {
-		return nil, fmt.Errorf("proxy URL must be absolute and include a host")
+		return nil, errors.New("proxy URL must be absolute and include a host")
 	}
 	if proxyURL.RawQuery != "" || proxyURL.ForceQuery || proxyURL.Fragment != "" || strings.Contains(rawURL, "#") {
-		return nil, fmt.Errorf("proxy URL must not include a query or fragment")
+		return nil, errors.New("proxy URL must not include a query or fragment")
 	}
 	if path := proxyURL.EscapedPath(); path != "" && path != "/" {
-		return nil, fmt.Errorf("proxy URL path must be empty or /")
+		return nil, errors.New("proxy URL path must be empty or /")
 	}
 
 	return proxyURL, nil

--- a/internal/proxyurl/proxyurl_test.go
+++ b/internal/proxyurl/proxyurl_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestParse(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		rawURL  string
@@ -31,6 +32,7 @@ func TestParse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := Parse(tt.rawURL)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Parse returned err=%v, wantErr=%v", err, tt.wantErr)
@@ -40,6 +42,7 @@ func TestParse(t *testing.T) {
 }
 
 func TestParseErrorDoesNotExposeCredentials(t *testing.T) {
+	t.Parallel()
 	rawURL := "http://user:super-secret@proxy.example:%zz"
 	_, err := Parse(rawURL)
 	if err == nil {

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -3,7 +3,7 @@ package redact
 import (
 	"errors"
 	"net/url"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -27,8 +27,9 @@ func String(value string, secrets ...string) string {
 	for variant := range variants {
 		ordered = append(ordered, variant)
 	}
-	sort.Slice(ordered, func(i, j int) bool {
-		return len(ordered[i]) > len(ordered[j])
+	slices.SortFunc(ordered, func(a, b string) int {
+		// sort by length descending
+		return len(b) - len(a)
 	})
 
 	for _, variant := range ordered {

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestStringRedactsRawAndURLEncodedSecrets(t *testing.T) {
+	t.Parallel()
 	secret := "token+/with space=&"
 	value := strings.Join([]string{
 		secret,
@@ -24,6 +25,7 @@ func TestStringRedactsRawAndURLEncodedSecrets(t *testing.T) {
 }
 
 func TestErrorHandlesNil(t *testing.T) {
+	t.Parallel()
 	if err := Error(nil, "secret"); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -35,6 +35,7 @@ func (c testConfig) UnmarshalKey(_ string, _ any) error {
 }
 
 func TestRegistryGetUsesRegistrationOrder(t *testing.T) {
+	t.Parallel()
 	r := New[string]("thing", "things.use")
 	r.Register("First", "things.first", func(ConfigReader) (string, error) {
 		return "", ErrNotConfigured
@@ -53,6 +54,7 @@ func TestRegistryGetUsesRegistrationOrder(t *testing.T) {
 }
 
 func TestRegistryRegisterRejectsAliasCollisions(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name              string
 		existingName      string
@@ -86,6 +88,7 @@ func TestRegistryRegisterRejectsAliasCollisions(t *testing.T) {
 	constructor := func(ConfigReader) (string, error) { return "value", nil }
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			r := New[string]("thing", "things.use")
 			r.Register(tt.existingName, tt.existingConfigKey, constructor)
 
@@ -100,6 +103,7 @@ func TestRegistryRegisterRejectsAliasCollisions(t *testing.T) {
 }
 
 func TestRegistryConcurrentRegisterAndGet(t *testing.T) {
+	t.Parallel()
 	r := New[string]("thing", "things.use")
 	r.Register("Default", "things.default", func(ConfigReader) (string, error) {
 		return "default", nil
@@ -161,6 +165,7 @@ func TestRegistryConcurrentRegisterAndGet(t *testing.T) {
 }
 
 func TestRegistryGetDoesNotHoldLockWhileCallingConstructor(t *testing.T) {
+	t.Parallel()
 	r := New[string]("thing", "things.use")
 	r.Register("First", "things.first", func(ConfigReader) (string, error) {
 		r.Register("Second", "things.second", func(ConfigReader) (string, error) {
@@ -191,6 +196,7 @@ func TestRegistryGetDoesNotHoldLockWhileCallingConstructor(t *testing.T) {
 }
 
 func TestRegistryGetStopsOnConfigurationError(t *testing.T) {
+	t.Parallel()
 	r := New[string]("thing", "things.use")
 	configErr := errors.New("bad config")
 	r.Register("First", "things.first", func(ConfigReader) (string, error) {
@@ -210,6 +216,7 @@ func TestRegistryGetStopsOnConfigurationError(t *testing.T) {
 }
 
 func TestRegistryGetRejectsNilConstructorValue(t *testing.T) {
+	t.Parallel()
 	r := New[any]("thing", "things.use")
 	r.Register("NilThing", "things.nil_thing", func(ConfigReader) (any, error) {
 		return nil, nil
@@ -228,6 +235,7 @@ func TestRegistryGetRejectsNilConstructorValue(t *testing.T) {
 }
 
 func TestRegistryRejectsTypedNilConstructorValue(t *testing.T) {
+	t.Parallel()
 	r := New[testService]("thing", "things.use")
 	r.Register("NilThing", "things.nil_thing", func(ConfigReader) (testService, error) {
 		var service *testServiceImpl
@@ -268,6 +276,7 @@ func TestRegistryRejectsTypedNilConstructorValue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			name, value, err := tt.lookup(tt.config)
 			if err == nil {
 				t.Fatal("expected typed-nil constructor value to return an error")
@@ -283,6 +292,7 @@ func TestRegistryRejectsTypedNilConstructorValue(t *testing.T) {
 }
 
 func TestRegistryGetUsesExplicitSelector(t *testing.T) {
+	t.Parallel()
 	r := New[string]("thing", "things.use")
 	r.Register("First", "things.first", func(ConfigReader) (string, error) {
 		return "first", nil
@@ -301,6 +311,7 @@ func TestRegistryGetUsesExplicitSelector(t *testing.T) {
 }
 
 func TestRegistryConfigKeyResolvesAliases(t *testing.T) {
+	t.Parallel()
 	r := New[string]("thing", "things.use")
 	r.Register("SecondThing", "things.second_thing", func(ConfigReader) (string, error) {
 		return "second", nil
@@ -318,6 +329,7 @@ func TestRegistryConfigKeyResolvesAliases(t *testing.T) {
 }
 
 func TestRegistryGetReportsSelectedButUnconfigured(t *testing.T) {
+	t.Parallel()
 	r := New[string]("thing", "things.use")
 	r.Register("First", "things.first", func(ConfigReader) (string, error) {
 		return "", ErrNotConfigured
@@ -333,6 +345,7 @@ func TestRegistryGetReportsSelectedButUnconfigured(t *testing.T) {
 }
 
 func TestRegistryGetReportsUnknownSelector(t *testing.T) {
+	t.Parallel()
 	r := New[string]("thing", "things.use")
 	r.Register("First", "things.first", func(ConfigReader) (string, error) {
 		return "first", nil
@@ -348,6 +361,7 @@ func TestRegistryGetReportsUnknownSelector(t *testing.T) {
 }
 
 func TestRegistryGetOptionalUsesFallbackWhenUnconfigured(t *testing.T) {
+	t.Parallel()
 	r := New[string]("thing", "things.use")
 	r.Register("First", "things.first", func(ConfigReader) (string, error) {
 		return "", ErrNotConfigured
@@ -363,6 +377,7 @@ func TestRegistryGetOptionalUsesFallbackWhenUnconfigured(t *testing.T) {
 }
 
 func TestRegistryGetOptionalReportsConfiguredError(t *testing.T) {
+	t.Parallel()
 	r := New[string]("thing", "things.use")
 	r.Register("First", "things.first", func(ConfigReader) (string, error) {
 		return "", errors.New("bad optional config")

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -116,9 +116,7 @@ func TestRegistryConcurrentRegisterAndGet(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for writer := range writers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			for registration := range registrationsEach {
 				name := fmt.Sprintf("Writer%dEntry%d", writer, registration)
@@ -127,14 +125,12 @@ func TestRegistryConcurrentRegisterAndGet(t *testing.T) {
 					return "registered", nil
 				})
 			}
-		}()
+		})
 	}
 
 	config := testConfig{"things.default": "configured"}
 	for range readers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			for range lookupsEach {
 				name, value, err := r.Get(config)
@@ -147,7 +143,7 @@ func TestRegistryConcurrentRegisterAndGet(t *testing.T) {
 					errs <- fmt.Errorf("GetOptional returned %q/%q, err=%v", name, value, err)
 				}
 			}
-		}()
+		})
 	}
 
 	close(start)

--- a/internal/restyretry/restyretry_test.go
+++ b/internal/restyretry/restyretry_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestConfigureTransient(t *testing.T) {
+	t.Parallel()
 	client := ConfigureTransient(resty.New())
 	if client.RetryCount != MaxRetries {
 		t.Fatalf("retry count = %d, want %d", client.RetryCount, MaxRetries)
@@ -30,6 +31,7 @@ func TestConfigureTransient(t *testing.T) {
 }
 
 func TestShouldRetry(t *testing.T) {
+	t.Parallel()
 	response := func(status int) *resty.Response {
 		return &resty.Response{RawResponse: &http.Response{StatusCode: status}}
 	}
@@ -52,6 +54,7 @@ func TestShouldRetry(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := shouldRetry(tt.response, tt.err); got != tt.want {
 				t.Fatalf("shouldRetry() = %v, want %v", got, tt.want)
 			}

--- a/internal/selfupdate/apply_integration_unix_test.go
+++ b/internal/selfupdate/apply_integration_unix_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestUpdaterApplyEndToEnd(t *testing.T) {
+	t.Parallel()
 	directory := t.TempDir()
 	targetPath := filepath.Join(directory, "uddns")
 	oldBinary := []byte("old binary")

--- a/internal/selfupdate/apply_unix_test.go
+++ b/internal/selfupdate/apply_unix_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestApplyCandidateAtomicallyReplacesExecutableAndCreatesBackup(t *testing.T) {
+	t.Parallel()
 	directory := t.TempDir()
 	targetPath := filepath.Join(directory, "uddns")
 	stagingDirectory := filepath.Join(directory, ".uddns-update-test")
@@ -60,6 +61,7 @@ func TestApplyCandidateAtomicallyReplacesExecutableAndCreatesBackup(t *testing.T
 }
 
 func TestApplyCandidateVersionMismatchLeavesTargetUnchanged(t *testing.T) {
+	t.Parallel()
 	directory := t.TempDir()
 	targetPath := filepath.Join(directory, "uddns")
 	stagingDirectory := filepath.Join(directory, ".uddns-update-test")
@@ -107,6 +109,7 @@ func TestApplyCandidateVersionMismatchLeavesTargetUnchanged(t *testing.T) {
 }
 
 func TestApplyCandidateRejectsStaleCurrentVersion(t *testing.T) {
+	t.Parallel()
 	directory := t.TempDir()
 	targetPath := filepath.Join(directory, "uddns")
 	stagingDirectory := filepath.Join(directory, ".uddns-update-test")
@@ -158,6 +161,7 @@ func TestApplyCandidateRejectsStaleCurrentVersion(t *testing.T) {
 }
 
 func TestApplyCandidateRejectsNonRegularTargets(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		createPath func(*testing.T, string)
@@ -186,6 +190,7 @@ func TestApplyCandidateRejectsNonRegularTargets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			directory := t.TempDir()
 			targetPath := filepath.Join(directory, "uddns")
 			tt.createPath(t, targetPath)
@@ -216,6 +221,7 @@ func TestApplyCandidateRejectsNonRegularTargets(t *testing.T) {
 }
 
 func TestApplyCandidateRejectsNonRegularCandidates(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		createPath func(*testing.T, string)
@@ -244,6 +250,7 @@ func TestApplyCandidateRejectsNonRegularCandidates(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			directory := t.TempDir()
 			targetPath := filepath.Join(directory, "uddns")
 			writeApplyTestFile(t, targetPath, "old executable", 0o755)
@@ -277,6 +284,7 @@ func TestApplyCandidateRejectsNonRegularCandidates(t *testing.T) {
 }
 
 func TestApplyCandidateRejectsConcurrentUpdate(t *testing.T) {
+	t.Parallel()
 	directory := t.TempDir()
 	targetPath := filepath.Join(directory, "uddns")
 	writeApplyTestFile(t, targetPath, "old executable", 0o755)
@@ -312,6 +320,7 @@ func TestApplyCandidateRejectsConcurrentUpdate(t *testing.T) {
 }
 
 func TestApplyCandidateFailurePreservesExistingPrevious(t *testing.T) {
+	t.Parallel()
 	directory := t.TempDir()
 	targetPath := filepath.Join(directory, "uddns")
 	previousPath := backupPath(targetPath)
@@ -361,6 +370,7 @@ func TestApplyCandidateFailurePreservesExistingPrevious(t *testing.T) {
 }
 
 func TestApplyCandidateRejectsExistingPendingRecoveryBackup(t *testing.T) {
+	t.Parallel()
 	directory := t.TempDir()
 	targetPath := filepath.Join(directory, "uddns")
 	stagingDirectory := filepath.Join(directory, ".uddns-update-test")
@@ -392,6 +402,7 @@ func TestApplyCandidateRejectsExistingPendingRecoveryBackup(t *testing.T) {
 }
 
 func TestRollbackExecutableExchangesCurrentAndPrevious(t *testing.T) {
+	t.Parallel()
 	directory := t.TempDir()
 	targetPath := filepath.Join(directory, "uddns")
 	previousPath := backupPath(targetPath)
@@ -423,6 +434,7 @@ func TestRollbackExecutableExchangesCurrentAndPrevious(t *testing.T) {
 }
 
 func TestRollbackExecutableRestoresDevelopmentBackup(t *testing.T) {
+	t.Parallel()
 	directory := t.TempDir()
 	targetPath := filepath.Join(directory, "uddns")
 	previousPath := backupPath(targetPath)
@@ -448,6 +460,7 @@ func TestRollbackExecutableRestoresDevelopmentBackup(t *testing.T) {
 }
 
 func TestRollbackExecutableRestoresCurrentWhenBackupPublishFails(t *testing.T) {
+	t.Parallel()
 	directory := t.TempDir()
 	targetPath := filepath.Join(directory, "uddns")
 	previousPath := backupPath(targetPath)
@@ -493,6 +506,7 @@ func TestRollbackExecutableRestoresCurrentWhenBackupPublishFails(t *testing.T) {
 }
 
 func TestRollbackExecutableWithoutPreviousLeavesTargetUnchanged(t *testing.T) {
+	t.Parallel()
 	directory := t.TempDir()
 	targetPath := filepath.Join(directory, "uddns")
 	writeApplyTestFile(t, targetPath, "current executable", 0o755)

--- a/internal/selfupdate/archive.go
+++ b/internal/selfupdate/archive.go
@@ -26,7 +26,7 @@ func extractExecutable(
 	case strings.HasSuffix(archiveName, ".zip"):
 		return extractZipExecutable(archivePath, expectedExecutable, destination)
 	default:
-		return fmt.Errorf("unsupported archive format")
+		return errors.New("unsupported archive format")
 	}
 }
 
@@ -61,17 +61,17 @@ func extractTarGzipExecutable(archivePath, expectedExecutable, destination strin
 		return fmt.Errorf("archive must contain only %s", expectedExecutable)
 	}
 	if header.Typeflag != tar.TypeReg {
-		return fmt.Errorf("archive executable must be a regular file")
+		return errors.New("archive executable must be a regular file")
 	}
 	if header.Size <= 0 || header.Size > maxExecutableSize {
-		return fmt.Errorf("archive executable has an invalid size")
+		return errors.New("archive executable has an invalid size")
 	}
 	if err := writeExecutable(destination, tarReader, header.Size); err != nil {
 		return err
 	}
 	if _, err := tarReader.Next(); !errors.Is(err, io.EOF) {
 		if err == nil {
-			return fmt.Errorf("archive must contain exactly one file")
+			return errors.New("archive must contain exactly one file")
 		}
 		return fmt.Errorf("read trailing tar member: %w", err)
 	}
@@ -79,7 +79,7 @@ func extractTarGzipExecutable(archivePath, expectedExecutable, destination strin
 		return fmt.Errorf("validate gzip stream: %w", err)
 	}
 	if _, err := bufferedFile.Peek(1); err == nil {
-		return fmt.Errorf("gzip archive contains trailing data")
+		return errors.New("gzip archive contains trailing data")
 	} else if !errors.Is(err, io.EOF) {
 		return fmt.Errorf("inspect trailing gzip data: %w", err)
 	}
@@ -102,17 +102,17 @@ func extractZipExecutable(archivePath, expectedExecutable, destination string) e
 	defer reader.Close()
 
 	if len(reader.File) != 1 {
-		return fmt.Errorf("archive must contain exactly one file")
+		return errors.New("archive must contain exactly one file")
 	}
 	member := reader.File[0]
 	if member.Name != expectedExecutable {
 		return fmt.Errorf("archive must contain only %s", expectedExecutable)
 	}
 	if !member.Mode().IsRegular() {
-		return fmt.Errorf("archive executable must be a regular file")
+		return errors.New("archive executable must be a regular file")
 	}
 	if member.UncompressedSize64 == 0 || member.UncompressedSize64 > maxExecutableSize {
-		return fmt.Errorf("archive executable has an invalid size")
+		return errors.New("archive executable has an invalid size")
 	}
 
 	memberReader, err := member.Open()
@@ -149,10 +149,10 @@ func writeExecutable(destination string, source io.Reader, expectedSize int64) e
 		return fmt.Errorf("extract executable: %w", err)
 	}
 	if written != expectedSize {
-		return fmt.Errorf("archive executable size mismatch")
+		return errors.New("archive executable size mismatch")
 	}
 	if written > maxExecutableSize {
-		return fmt.Errorf("archive executable exceeds the size limit")
+		return errors.New("archive executable exceeds the size limit")
 	}
 	if err := file.Sync(); err != nil {
 		return err

--- a/internal/selfupdate/archive_test.go
+++ b/internal/selfupdate/archive_test.go
@@ -426,7 +426,7 @@ func truncateArchiveTestFile(t *testing.T, path string, removeBytes int64) {
 		t.Fatalf("stat archive fixture: %v", err)
 	}
 	if info.Size() <= removeBytes {
-		t.Fatalf("archive fixture is too small to truncate")
+		t.Fatal("archive fixture is too small to truncate")
 	}
 	if err := os.Truncate(path, info.Size()-removeBytes); err != nil {
 		t.Fatalf("truncate archive fixture: %v", err)

--- a/internal/selfupdate/archive_test.go
+++ b/internal/selfupdate/archive_test.go
@@ -309,7 +309,6 @@ func TestWriteExecutableRejectsSizeMismatch(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/selfupdate/asset_test.go
+++ b/internal/selfupdate/asset_test.go
@@ -3,6 +3,7 @@ package selfupdate
 import "testing"
 
 func TestAssetNameReleaseMatrix(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		goos   string
@@ -61,6 +62,7 @@ func TestAssetNameReleaseMatrix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := assetName("uddns", "1.9.0", tt.goos, tt.goarch)
 			if err != nil {
 				t.Fatalf("assetName returned unexpected error: %v", err)
@@ -73,6 +75,7 @@ func TestAssetNameReleaseMatrix(t *testing.T) {
 }
 
 func TestAssetNameAcceptsArtifactComponents(t *testing.T) {
+	t.Parallel()
 	got, err := assetName("ud-dns", "1.9.0-rc.1", "linux", "amd64")
 	if err != nil {
 		t.Fatalf("assetName returned unexpected error: %v", err)
@@ -84,6 +87,7 @@ func TestAssetNameAcceptsArtifactComponents(t *testing.T) {
 }
 
 func TestAssetNameRejectsInvalidInput(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		project string
@@ -193,6 +197,7 @@ func TestAssetNameRejectsInvalidInput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := assetName(
 				tt.project,
 				tt.version,
@@ -207,6 +212,7 @@ func TestAssetNameRejectsInvalidInput(t *testing.T) {
 }
 
 func TestArchiveExecutableName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		project string
@@ -235,6 +241,7 @@ func TestArchiveExecutableName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := archiveExecutableName(tt.project, tt.goos); got != tt.want {
 				t.Fatalf(
 					"archiveExecutableName(%q, %q) = %q, want %q",

--- a/internal/selfupdate/download_test.go
+++ b/internal/selfupdate/download_test.go
@@ -95,7 +95,6 @@ func TestChecksumForAssetRejectsMalformedContent(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/selfupdate/release.go
+++ b/internal/selfupdate/release.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -42,7 +43,7 @@ func hardenedHTTPClient(client *http.Client, testEndpoint bool) *http.Client {
 	originalRedirectCheck := hardened.CheckRedirect
 	hardened.CheckRedirect = func(request *http.Request, via []*http.Request) error {
 		if len(via) >= maxRedirects {
-			return fmt.Errorf("too many redirects")
+			return errors.New("too many redirects")
 		}
 		if !testEndpoint {
 			if err := validateGitHubURL(request.URL); err != nil {
@@ -89,7 +90,7 @@ func (u *Updater) fetchRelease(
 		)
 	}
 	if response.ContentLength > maxReleaseMetadataSize {
-		return releaseMetadata{}, fmt.Errorf("release metadata exceeds the size limit")
+		return releaseMetadata{}, errors.New("release metadata exceeds the size limit")
 	}
 
 	body, err := io.ReadAll(io.LimitReader(response.Body, maxReleaseMetadataSize+1))

--- a/internal/selfupdate/release_test.go
+++ b/internal/selfupdate/release_test.go
@@ -313,18 +313,16 @@ func TestUpdaterCheckUsesProductionDownloadURLAllowlist(t *testing.T) {
 		{
 			name: "different repository",
 			mutate: func(release *releaseMetadata) {
-				release.Assets[0].BrowserDownloadURL =
-					"https://github.com/other/uddns/releases/download/v1.9.0/" +
-						releaseTestAssetName
+				release.Assets[0].BrowserDownloadURL = "https://github.com/other/uddns/releases/download/v1.9.0/" +
+					releaseTestAssetName
 			},
 			wantErrContains: "selected repository release",
 		},
 		{
 			name: "different release tag",
 			mutate: func(release *releaseMetadata) {
-				release.Assets[0].BrowserDownloadURL =
-					"https://github.com/we11adam/uddns/releases/download/v1.8.0/" +
-						releaseTestAssetName
+				release.Assets[0].BrowserDownloadURL = "https://github.com/we11adam/uddns/releases/download/v1.8.0/" +
+					releaseTestAssetName
 			},
 			wantErrContains: "selected repository release",
 		},

--- a/internal/selfupdate/release_test.go
+++ b/internal/selfupdate/release_test.go
@@ -21,6 +21,7 @@ func (f releaseTestRoundTripFunc) RoundTrip(request *http.Request) (*http.Respon
 }
 
 func TestFetchReleaseEndpointAndHeaders(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		requestedVersion string
@@ -44,6 +45,7 @@ func TestFetchReleaseEndpointAndHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var gotRequest *http.Request
 			body := releaseTestMarshalMetadata(t, releaseTestMetadata())
 			updater := releaseTestUpdater(t, "1.8.0", releaseTestRoundTripFunc(
@@ -89,6 +91,7 @@ func TestFetchReleaseEndpointAndHeaders(t *testing.T) {
 }
 
 func TestFetchReleaseRejectsInvalidResponses(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		statusCode      int
@@ -135,6 +138,7 @@ func TestFetchReleaseRejectsInvalidResponses(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			updater := releaseTestUpdater(t, "1.8.0", releaseTestRoundTripFunc(
 				func(*http.Request) (*http.Response, error) {
 					response := releaseTestResponse(tt.statusCode, tt.body)
@@ -157,6 +161,7 @@ func TestFetchReleaseRejectsInvalidResponses(t *testing.T) {
 }
 
 func TestFetchReleaseRejectsUndeclaredOversizedMetadata(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		body string
@@ -175,6 +180,7 @@ func TestFetchReleaseRejectsUndeclaredOversizedMetadata(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			updater := releaseTestUpdater(t, "1.8.0", releaseTestRoundTripFunc(
 				func(*http.Request) (*http.Response, error) {
 					response := releaseTestResponse(http.StatusOK, tt.body)
@@ -191,6 +197,7 @@ func TestFetchReleaseRejectsUndeclaredOversizedMetadata(t *testing.T) {
 }
 
 func TestValidateGitHubURLAllowlist(t *testing.T) {
+	t.Parallel()
 	allowed := []string{
 		"https://api.github.com/repos/we11adam/uddns/releases/latest",
 		"https://github.com/we11adam/uddns/releases/download/v1.9.0/" + releaseTestAssetName,
@@ -200,6 +207,7 @@ func TestValidateGitHubURLAllowlist(t *testing.T) {
 	}
 	for _, rawURL := range allowed {
 		t.Run("allow "+rawURL, func(t *testing.T) {
+			t.Parallel()
 			parsed, err := url.Parse(rawURL)
 			if err != nil {
 				t.Fatalf("url.Parse returned error: %v", err)
@@ -258,6 +266,7 @@ func TestValidateGitHubURLAllowlist(t *testing.T) {
 	}
 	for _, tt := range rejected {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			parsed, err := url.Parse(tt.rawURL)
 			if err != nil {
 				t.Fatalf("url.Parse returned error: %v", err)
@@ -274,6 +283,7 @@ func TestValidateGitHubURLAllowlist(t *testing.T) {
 }
 
 func TestUpdaterCheckUsesProductionDownloadURLAllowlist(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		mutate          func(*releaseMetadata)
@@ -329,6 +339,7 @@ func TestUpdaterCheckUsesProductionDownloadURLAllowlist(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			release := releaseTestMetadata()
 			tt.mutate(&release)
 			body := releaseTestMarshalMetadata(t, release)

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestUpdaterCheckBuildsCompletePlan(t *testing.T) {
+	t.Parallel()
 	release := releaseTestMetadata()
 	body := releaseTestMarshalMetadata(t, release)
 	updater := releaseTestUpdater(t, "1.8.0", releaseTestRoundTripFunc(
@@ -57,6 +58,7 @@ func TestUpdaterCheckBuildsCompletePlan(t *testing.T) {
 }
 
 func TestUpdaterCheckVersionStatuses(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		currentVersion string
@@ -92,6 +94,7 @@ func TestUpdaterCheckVersionStatuses(t *testing.T) {
 	body := releaseTestMarshalMetadata(t, releaseTestMetadata())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			updater := releaseTestUpdater(t, tt.currentVersion, releaseTestRoundTripFunc(
 				func(*http.Request) (*http.Response, error) {
 					return releaseTestResponse(http.StatusOK, body), nil
@@ -110,6 +113,7 @@ func TestUpdaterCheckVersionStatuses(t *testing.T) {
 }
 
 func TestUpdateStatusRejectsInvalidCurrentVersion(t *testing.T) {
+	t.Parallel()
 	target := mustParseSemanticVersion(t, "1.9.0")
 	invalid := []string{
 		"",
@@ -122,6 +126,7 @@ func TestUpdateStatusRejectsInvalidCurrentVersion(t *testing.T) {
 
 	for _, current := range invalid {
 		t.Run(current, func(t *testing.T) {
+			t.Parallel()
 			if _, err := updateStatus(current, target); err == nil {
 				t.Fatalf("updateStatus(%q) returned nil error", current)
 			}
@@ -130,6 +135,7 @@ func TestUpdateStatusRejectsInvalidCurrentVersion(t *testing.T) {
 }
 
 func TestUpdaterCheckRejectsReleaseState(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		requestedVersion string
@@ -176,6 +182,7 @@ func TestUpdaterCheckRejectsReleaseState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			release := releaseTestMetadata()
 			tt.mutate(&release)
 			body := releaseTestMarshalMetadata(t, release)
@@ -197,6 +204,7 @@ func TestUpdaterCheckRejectsReleaseState(t *testing.T) {
 }
 
 func TestUpdaterCheckRejectsInvalidCurrentVersion(t *testing.T) {
+	t.Parallel()
 	body := releaseTestMarshalMetadata(t, releaseTestMetadata())
 	updater := releaseTestUpdater(t, "1.9", releaseTestRoundTripFunc(
 		func(*http.Request) (*http.Response, error) {
@@ -214,6 +222,7 @@ func TestUpdaterCheckRejectsInvalidCurrentVersion(t *testing.T) {
 }
 
 func TestUpdaterCheckRejectsInvalidRequestedVersionBeforeHTTP(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		requested       string
@@ -238,6 +247,7 @@ func TestUpdaterCheckRejectsInvalidRequestedVersionBeforeHTTP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			called := false
 			updater := releaseTestUpdater(t, "1.8.0", releaseTestRoundTripFunc(
 				func(*http.Request) (*http.Response, error) {
@@ -261,6 +271,7 @@ func TestUpdaterCheckRejectsInvalidRequestedVersionBeforeHTTP(t *testing.T) {
 }
 
 func TestNewRejectsEmptyCurrentVersion(t *testing.T) {
+	t.Parallel()
 	_, err := New(Config{
 		ExecutablePath: "/usr/local/bin/uddns",
 		GOOS:           "linux",
@@ -275,6 +286,7 @@ func TestNewRejectsEmptyCurrentVersion(t *testing.T) {
 }
 
 func TestUpdaterCheckRequiresUniqueExactAssets(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		mutate          func(*releaseMetadata)
@@ -347,6 +359,7 @@ func TestUpdaterCheckRequiresUniqueExactAssets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			release := releaseTestMetadata()
 			tt.mutate(&release)
 			body := releaseTestMarshalMetadata(t, release)
@@ -368,6 +381,7 @@ func TestUpdaterCheckRequiresUniqueExactAssets(t *testing.T) {
 }
 
 func TestUpdaterApplyRejectsLegacyReleaseBeforeDownload(t *testing.T) {
+	t.Parallel()
 	updater, err := New(Config{
 		CurrentVersion: "1.9.0",
 		ExecutablePath: "/usr/local/bin/uddns",

--- a/internal/selfupdate/signature.go
+++ b/internal/selfupdate/signature.go
@@ -1,6 +1,7 @@
 package selfupdate
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -49,7 +50,7 @@ func verifyChecksumSignature(
 	trustedPublicKeys []minisign.PublicKey,
 ) error {
 	if len(trustedPublicKeys) == 0 {
-		return fmt.Errorf("no trusted release signing keys configured")
+		return errors.New("no trusted release signing keys configured")
 	}
 
 	checksums, err := os.ReadFile(checksumPath)
@@ -57,14 +58,14 @@ func verifyChecksumSignature(
 		return fmt.Errorf("read checksums for signature verification: %w", err)
 	}
 	if len(checksums) > maxChecksumSize {
-		return fmt.Errorf("checksums exceed the size limit")
+		return errors.New("checksums exceed the size limit")
 	}
 	signature, err := os.ReadFile(signaturePath)
 	if err != nil {
 		return fmt.Errorf("read checksum signature: %w", err)
 	}
 	if len(signature) > maxSignatureSize {
-		return fmt.Errorf("checksum signature exceeds the size limit")
+		return errors.New("checksum signature exceeds the size limit")
 	}
 
 	for _, publicKey := range trustedPublicKeys {
@@ -72,5 +73,5 @@ func verifyChecksumSignature(
 			return nil
 		}
 	}
-	return fmt.Errorf("checksum signature verification failed")
+	return errors.New("checksum signature verification failed")
 }

--- a/internal/selfupdate/signature_test.go
+++ b/internal/selfupdate/signature_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestParseTrustedPublicKeys(t *testing.T) {
+	t.Parallel()
 	first, _, err := minisign.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("generate first key: %v", err)
@@ -44,6 +45,7 @@ func TestParseTrustedPublicKeys(t *testing.T) {
 }
 
 func TestVerifyChecksumSignature(t *testing.T) {
+	t.Parallel()
 	publicKey, privateKey, err := minisign.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("generate signing key: %v", err)
@@ -105,6 +107,7 @@ func TestVerifyChecksumSignature(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			directory := t.TempDir()
 			checksumPath := filepath.Join(directory, "checksums.txt")
 			signaturePath := filepath.Join(directory, checksumSignatureName)
@@ -124,6 +127,7 @@ func TestVerifyChecksumSignature(t *testing.T) {
 }
 
 func TestDownloadCandidateVerifiesSignatureBeforeArchiveDownload(t *testing.T) {
+	t.Parallel()
 	publicKey, privateKey, err := minisign.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("generate signing key: %v", err)
@@ -168,6 +172,7 @@ func TestDownloadCandidateVerifiesSignatureBeforeArchiveDownload(t *testing.T) {
 }
 
 func TestNewRejectsInvalidTrustedPublicKey(t *testing.T) {
+	t.Parallel()
 	_, err := New(Config{
 		CurrentVersion:    "1.8.0",
 		ExecutablePath:    filepath.Join(t.TempDir(), "uddns"),
@@ -181,6 +186,7 @@ func TestNewRejectsInvalidTrustedPublicKey(t *testing.T) {
 }
 
 func TestEmbeddedReleasePublicKeys(t *testing.T) {
+	t.Parallel()
 	original := releasePublicKeys
 	t.Cleanup(func() {
 		releasePublicKeys = original

--- a/internal/selfupdate/signature_test.go
+++ b/internal/selfupdate/signature_test.go
@@ -33,7 +33,7 @@ func TestParseTrustedPublicKeys(t *testing.T) {
 		t.Fatalf("parseTrustedPublicKeys returned error: %v", err)
 	}
 	if len(keys) != 2 || !keys[0].Equal(first) || !keys[1].Equal(second) {
-		t.Fatalf("parsed keys do not match input")
+		t.Fatal("parsed keys do not match input")
 	}
 
 	for _, values := range [][]string{{""}, {"not-a-minisign-key"}} {

--- a/internal/selfupdate/verify.go
+++ b/internal/selfupdate/verify.go
@@ -3,6 +3,7 @@ package selfupdate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -30,7 +31,7 @@ func inspectBinaryVersion(ctx context.Context, path string) (string, error) {
 		return "", err
 	}
 	if info.Version == "" {
-		return "", fmt.Errorf("staged binary did not report a version")
+		return "", errors.New("staged binary did not report a version")
 	}
 	return info.Version, nil
 }
@@ -46,7 +47,7 @@ func inspectBinaryPlatform(
 		return err
 	}
 	if info.GOOS == "" || info.GOARCH == "" {
-		return fmt.Errorf("staged binary did not report its runtime target")
+		return errors.New("staged binary did not report its runtime target")
 	}
 	if info.GOOS != expectedGOOS || info.GOARCH != expectedGOARCH {
 		return fmt.Errorf(
@@ -83,7 +84,7 @@ func inspectBinaryInfo(ctx context.Context, path string) (binaryInfo, error) {
 	if len(output) > maxVersionOutput {
 		_ = command.Process.Kill()
 		_ = command.Wait()
-		return binaryInfo{}, fmt.Errorf("staged binary version output exceeds the size limit")
+		return binaryInfo{}, errors.New("staged binary version output exceeds the size limit")
 	}
 	if err := command.Wait(); err != nil {
 		return binaryInfo{}, fmt.Errorf("execute staged binary: %w", err)

--- a/internal/selfupdate/verify_unix_test.go
+++ b/internal/selfupdate/verify_unix_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestInspectBinaryVersion(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		script          string
@@ -41,6 +42,7 @@ func TestInspectBinaryVersion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			path := writeVersionScript(t, test.script)
 			version, err := inspectBinaryVersion(context.Background(), path)
 			if test.wantErrContains == "" {
@@ -60,6 +62,7 @@ func TestInspectBinaryVersion(t *testing.T) {
 }
 
 func TestInspectBinaryPlatform(t *testing.T) {
+	t.Parallel()
 	path := writeVersionScript(
 		t,
 		`printf '%s\n' '{"version":"1.9.0","goos":"darwin","goarch":"amd64"}'`,
@@ -84,6 +87,7 @@ func TestInspectBinaryPlatform(t *testing.T) {
 }
 
 func TestInspectBinaryPlatformRequiresTargetFields(t *testing.T) {
+	t.Parallel()
 	path := writeVersionScript(
 		t,
 		`printf '%s\n' '{"version":"1.9.0"}'`,
@@ -100,6 +104,7 @@ func TestInspectBinaryPlatformRequiresTargetFields(t *testing.T) {
 }
 
 func TestInspectBinaryVersionBoundsOutput(t *testing.T) {
+	t.Parallel()
 	path := writeVersionScript(
 		t,
 		`while :; do printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'; done`,

--- a/internal/selfupdate/verify_unix_test.go
+++ b/internal/selfupdate/verify_unix_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestInspectBinaryVersion(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name            string
 		script          string
@@ -42,7 +41,6 @@ func TestInspectBinaryVersion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			path := writeVersionScript(t, test.script)
 			version, err := inspectBinaryVersion(context.Background(), path)
 			if test.wantErrContains == "" {
@@ -62,7 +60,6 @@ func TestInspectBinaryVersion(t *testing.T) {
 }
 
 func TestInspectBinaryPlatform(t *testing.T) {
-	t.Parallel()
 	path := writeVersionScript(
 		t,
 		`printf '%s\n' '{"version":"1.9.0","goos":"darwin","goarch":"amd64"}'`,
@@ -87,7 +84,6 @@ func TestInspectBinaryPlatform(t *testing.T) {
 }
 
 func TestInspectBinaryPlatformRequiresTargetFields(t *testing.T) {
-	t.Parallel()
 	path := writeVersionScript(
 		t,
 		`printf '%s\n' '{"version":"1.9.0"}'`,
@@ -104,7 +100,6 @@ func TestInspectBinaryPlatformRequiresTargetFields(t *testing.T) {
 }
 
 func TestInspectBinaryVersionBoundsOutput(t *testing.T) {
-	t.Parallel()
 	path := writeVersionScript(
 		t,
 		`while :; do printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'; done`,

--- a/internal/selfupdate/version.go
+++ b/internal/selfupdate/version.go
@@ -74,7 +74,7 @@ func parseIdentifiers(value string, rejectNumericLeadingZero bool) ([]string, er
 		}
 
 		numeric := true
-		for i := 0; i < len(identifier); i++ {
+		for i := range len(identifier) {
 			character := identifier[i]
 			if !isIdentifierCharacter(character) {
 				return nil, fmt.Errorf("identifier %q contains an invalid character", identifier)
@@ -98,7 +98,7 @@ func validateNumericIdentifier(identifier string) error {
 	if len(identifier) > 1 && identifier[0] == '0' {
 		return fmt.Errorf("numeric identifier must not contain a leading zero")
 	}
-	for i := 0; i < len(identifier); i++ {
+	for i := range len(identifier) {
 		if identifier[i] < '0' || identifier[i] > '9' {
 			return fmt.Errorf("identifier must contain only ASCII digits")
 		}
@@ -175,7 +175,7 @@ func compareInts(a, b int) int {
 }
 
 func isNumericIdentifier(identifier string) bool {
-	for i := 0; i < len(identifier); i++ {
+	for i := range len(identifier) {
 		if identifier[i] < '0' || identifier[i] > '9' {
 			return false
 		}

--- a/internal/selfupdate/version_test.go
+++ b/internal/selfupdate/version_test.go
@@ -3,6 +3,7 @@ package selfupdate
 import "testing"
 
 func TestParseSemanticVersion(t *testing.T) {
+	t.Parallel()
 	huge := "1234567890123456789012345678901234567890.2.3"
 	tests := []struct {
 		name           string
@@ -47,6 +48,7 @@ func TestParseSemanticVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			version, err := parseSemanticVersion(tt.input)
 			if err != nil {
 				t.Fatalf("parseSemanticVersion(%q) returned error: %v", tt.input, err)
@@ -65,6 +67,7 @@ func TestParseSemanticVersion(t *testing.T) {
 }
 
 func TestParseSemanticVersionRejectsInvalidInput(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string
@@ -104,6 +107,7 @@ func TestParseSemanticVersionRejectsInvalidInput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if version, err := parseSemanticVersion(tt.input); err == nil {
 				t.Fatalf("parseSemanticVersion(%q) = %#v, want error", tt.input, version)
 			}
@@ -112,6 +116,7 @@ func TestParseSemanticVersionRejectsInvalidInput(t *testing.T) {
 }
 
 func TestCompareSemanticVersions(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		a    string
@@ -145,6 +150,7 @@ func TestCompareSemanticVersions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			a := mustParseSemanticVersion(t, tt.a)
 			b := mustParseSemanticVersion(t, tt.b)
 
@@ -159,6 +165,7 @@ func TestCompareSemanticVersions(t *testing.T) {
 }
 
 func TestCompareSemanticVersionsFollowsSemVerPrecedenceExample(t *testing.T) {
+	t.Parallel()
 	ordered := []string{
 		"1.0.0-alpha",
 		"1.0.0-alpha.1",

--- a/internal/selfupdate/version_test.go
+++ b/internal/selfupdate/version_test.go
@@ -170,7 +170,7 @@ func TestCompareSemanticVersionsFollowsSemVerPrecedenceExample(t *testing.T) {
 		"1.0.0",
 	}
 
-	for i := 0; i < len(ordered)-1; i++ {
+	for i := range len(ordered) - 1 {
 		a := mustParseSemanticVersion(t, ordered[i])
 		b := mustParseSemanticVersion(t, ordered[i+1])
 		if got := compareSemanticVersions(a, b); got != -1 {

--- a/logging.go
+++ b/logging.go
@@ -339,7 +339,7 @@ func (w *calendarRotatingWriter) cleanupOldLogs(now time.Time) {
 			continue
 		}
 
-		logDate, ok := parseRotatedLogDate(entry.Name(), w.prefix)
+		logDate, ok := parseRotatedLogDate(entry.Name(), w.prefix, now.Location())
 		if !ok || !logDate.Before(cutoff) {
 			continue
 		}
@@ -351,7 +351,7 @@ func (w *calendarRotatingWriter) cleanupOldLogs(now time.Time) {
 	}
 }
 
-func parseRotatedLogDate(name, prefix string) (time.Time, bool) {
+func parseRotatedLogDate(name, prefix string, location *time.Location) (time.Time, bool) {
 	dateText, ok := strings.CutPrefix(name, prefix+"-")
 	if !ok {
 		return time.Time{}, false
@@ -361,7 +361,7 @@ func parseRotatedLogDate(name, prefix string) (time.Time, bool) {
 		return time.Time{}, false
 	}
 
-	date, err := time.ParseInLocation(logDateLayout, dateText, time.Local)
+	date, err := time.ParseInLocation(logDateLayout, dateText, location)
 	if err != nil {
 		return time.Time{}, false
 	}

--- a/logging.go
+++ b/logging.go
@@ -21,8 +21,8 @@ const (
 	defaultLogRetentionDays = 7
 	logDateLayout           = "2006-01-02"
 	logFilePrefix           = "uddns"
-	logDirMode              = 0700
-	logFileMode             = 0600
+	logDirMode              = 0o700
+	logFileMode             = 0o600
 )
 
 type logConfigValue struct {

--- a/logging_test.go
+++ b/logging_test.go
@@ -192,7 +192,7 @@ func TestCalendarRotatingWriterCleanupRemainsInOpenedRoot(t *testing.T) {
 
 func TestParseRotatedLogDate(t *testing.T) {
 	t.Parallel()
-	date, ok := parseRotatedLogDate("uddns-2026-05-21.log", logFilePrefix)
+	date, ok := parseRotatedLogDate("uddns-2026-05-21.log", logFilePrefix, time.UTC)
 	if !ok {
 		t.Fatal("expected valid rotated log name")
 	}
@@ -209,7 +209,7 @@ func TestParseRotatedLogDate(t *testing.T) {
 	for _, name := range invalidNames {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			if _, ok := parseRotatedLogDate(name, logFilePrefix); ok {
+			if _, ok := parseRotatedLogDate(name, logFilePrefix, time.UTC); ok {
 				t.Fatalf("expected %q to be ignored", name)
 			}
 		})

--- a/logging_test.go
+++ b/logging_test.go
@@ -86,10 +86,10 @@ func TestCalendarRotatingWriterCreatesPrivateDirectoryAndLogFile(t *testing.T) {
 func TestCalendarRotatingWriterRestrictsExistingDirectory(t *testing.T) {
 	t.Parallel()
 	dir := filepath.Join(t.TempDir(), "logs")
-	if err := os.Mkdir(dir, 0777); err != nil {
+	if err := os.Mkdir(dir, 0o777); err != nil {
 		t.Fatalf("create exposed log directory: %v", err)
 	}
-	if err := os.Chmod(dir, 0777); err != nil {
+	if err := os.Chmod(dir, 0o777); err != nil {
 		t.Fatalf("expose log directory: %v", err)
 	}
 
@@ -244,7 +244,7 @@ func TestLogProcessAttrsIncludesVersionAndPID(t *testing.T) {
 
 func writeTestFile(t *testing.T, path, content string) {
 	t.Helper()
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write test file %s: %v", path, err)
 	}
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestCalendarRotatingWriterRotatesByDateAndRemovesExpiredLogs(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	now := time.Date(2026, 5, 21, 10, 0, 0, 0, time.Local)
 
@@ -52,6 +53,7 @@ func TestCalendarRotatingWriterRotatesByDateAndRemovesExpiredLogs(t *testing.T) 
 }
 
 func TestCalendarRotatingWriterCreatesPrivateDirectoryAndLogFile(t *testing.T) {
+	t.Parallel()
 	dir := filepath.Join(t.TempDir(), "logs")
 	now := time.Date(2026, 5, 21, 10, 0, 0, 0, time.Local)
 
@@ -82,6 +84,7 @@ func TestCalendarRotatingWriterCreatesPrivateDirectoryAndLogFile(t *testing.T) {
 }
 
 func TestCalendarRotatingWriterRestrictsExistingDirectory(t *testing.T) {
+	t.Parallel()
 	dir := filepath.Join(t.TempDir(), "logs")
 	if err := os.Mkdir(dir, 0777); err != nil {
 		t.Fatalf("create exposed log directory: %v", err)
@@ -108,6 +111,7 @@ func TestCalendarRotatingWriterRestrictsExistingDirectory(t *testing.T) {
 }
 
 func TestCalendarRotatingWriterRejectsLogDirectorySymlink(t *testing.T) {
+	t.Parallel()
 	target := t.TempDir()
 	dir := filepath.Join(t.TempDir(), "logs")
 	if err := os.Symlink(target, dir); err != nil {
@@ -123,6 +127,7 @@ func TestCalendarRotatingWriterRejectsLogDirectorySymlink(t *testing.T) {
 }
 
 func TestCalendarRotatingWriterRejectsCurrentLogSymlink(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	target := filepath.Join(t.TempDir(), "target.log")
 	writeTestFile(t, target, "unchanged\n")
@@ -148,6 +153,7 @@ func TestCalendarRotatingWriterRejectsCurrentLogSymlink(t *testing.T) {
 }
 
 func TestCalendarRotatingWriterCleanupRemainsInOpenedRoot(t *testing.T) {
+	t.Parallel()
 	baseDir := t.TempDir()
 	dir := filepath.Join(baseDir, "logs")
 	if err := os.Mkdir(dir, logDirMode); err != nil {
@@ -185,6 +191,7 @@ func TestCalendarRotatingWriterCleanupRemainsInOpenedRoot(t *testing.T) {
 }
 
 func TestParseRotatedLogDate(t *testing.T) {
+	t.Parallel()
 	date, ok := parseRotatedLogDate("uddns-2026-05-21.log", logFilePrefix)
 	if !ok {
 		t.Fatal("expected valid rotated log name")
@@ -201,6 +208,7 @@ func TestParseRotatedLogDate(t *testing.T) {
 	}
 	for _, name := range invalidNames {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			if _, ok := parseRotatedLogDate(name, logFilePrefix); ok {
 				t.Fatalf("expected %q to be ignored", name)
 			}
@@ -209,6 +217,7 @@ func TestParseRotatedLogDate(t *testing.T) {
 }
 
 func TestLogProcessAttrsIncludesVersionAndPID(t *testing.T) {
+	t.Parallel()
 	oldVersion := version
 	version = "v-test"
 	t.Cleanup(func() {

--- a/logging_test.go
+++ b/logging_test.go
@@ -11,7 +11,7 @@ import (
 func TestCalendarRotatingWriterRotatesByDateAndRemovesExpiredLogs(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	now := time.Date(2026, 5, 21, 10, 0, 0, 0, time.Local)
+	now := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
 
 	writeTestFile(t, filepath.Join(dir, "uddns-2026-05-19.log"), "old\n")
 	writeTestFile(t, filepath.Join(dir, "uddns-2026-05-20.log"), "keep\n")
@@ -34,7 +34,7 @@ func TestCalendarRotatingWriterRotatesByDateAndRemovesExpiredLogs(t *testing.T) 
 	assertExists(t, filepath.Join(dir, "uddns-2026-05-21.log"))
 	assertExists(t, filepath.Join(dir, "other-2026-05-19.log"))
 
-	now = time.Date(2026, 5, 22, 1, 0, 0, 0, time.Local)
+	now = time.Date(2026, 5, 22, 1, 0, 0, 0, time.UTC)
 	if _, err := writer.Write([]byte("tomorrow\n")); err != nil {
 		t.Fatalf("write rotated log: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestCalendarRotatingWriterRotatesByDateAndRemovesExpiredLogs(t *testing.T) 
 func TestCalendarRotatingWriterCreatesPrivateDirectoryAndLogFile(t *testing.T) {
 	t.Parallel()
 	dir := filepath.Join(t.TempDir(), "logs")
-	now := time.Date(2026, 5, 21, 10, 0, 0, 0, time.Local)
+	now := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
 
 	writer, err := newCalendarRotatingWriterWithClock(dir, logFilePrefix, 2, func() time.Time {
 		return now
@@ -94,7 +94,7 @@ func TestCalendarRotatingWriterRestrictsExistingDirectory(t *testing.T) {
 	}
 
 	writer, err := newCalendarRotatingWriterWithClock(dir, logFilePrefix, 2, func() time.Time {
-		return time.Date(2026, 5, 21, 10, 0, 0, 0, time.Local)
+		return time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
 	})
 	if err != nil {
 		t.Fatalf("newCalendarRotatingWriterWithClock returned error: %v", err)
@@ -119,7 +119,7 @@ func TestCalendarRotatingWriterRejectsLogDirectorySymlink(t *testing.T) {
 	}
 
 	_, err := newCalendarRotatingWriterWithClock(dir, logFilePrefix, 2, func() time.Time {
-		return time.Date(2026, 5, 21, 10, 0, 0, 0, time.Local)
+		return time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
 	})
 	if err == nil {
 		t.Fatal("expected log directory symlink to be rejected")
@@ -137,7 +137,7 @@ func TestCalendarRotatingWriterRejectsCurrentLogSymlink(t *testing.T) {
 	}
 
 	_, err := newCalendarRotatingWriterWithClock(dir, logFilePrefix, 2, func() time.Time {
-		return time.Date(2026, 5, 21, 10, 0, 0, 0, time.Local)
+		return time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
 	})
 	if err == nil {
 		t.Fatal("expected current log symlink to be rejected")
@@ -161,7 +161,7 @@ func TestCalendarRotatingWriterCleanupRemainsInOpenedRoot(t *testing.T) {
 	}
 	writeTestFile(t, filepath.Join(dir, "uddns-2026-05-20.log"), "original\n")
 
-	now := time.Date(2026, 5, 21, 10, 0, 0, 0, time.Local)
+	now := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
 	writer, err := newCalendarRotatingWriterWithClock(dir, logFilePrefix, 2, func() time.Time {
 		return now
 	})
@@ -180,7 +180,7 @@ func TestCalendarRotatingWriterCleanupRemainsInOpenedRoot(t *testing.T) {
 	replacementLog := filepath.Join(dir, "uddns-2026-05-20.log")
 	writeTestFile(t, replacementLog, "replacement\n")
 
-	now = time.Date(2026, 5, 22, 1, 0, 0, 0, time.Local)
+	now = time.Date(2026, 5, 22, 1, 0, 0, 0, time.UTC)
 	if _, err := writer.Write([]byte("tomorrow\n")); err != nil {
 		t.Fatalf("write rotated log: %v", err)
 	}

--- a/logging_unix_test.go
+++ b/logging_unix_test.go
@@ -13,7 +13,7 @@ func TestCalendarRotatingWriterRejectsCurrentLogFIFO(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "uddns-2026-05-21.log")
-	if err := syscall.Mkfifo(logPath, 0600); err != nil {
+	if err := syscall.Mkfifo(logPath, 0o600); err != nil {
 		t.Skipf("create log FIFO: %v", err)
 	}
 

--- a/logging_unix_test.go
+++ b/logging_unix_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestCalendarRotatingWriterRejectsCurrentLogFIFO(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "uddns-2026-05-21.log")
 	if err := syscall.Mkfifo(logPath, 0600); err != nil {

--- a/logging_unix_test.go
+++ b/logging_unix_test.go
@@ -18,7 +18,7 @@ func TestCalendarRotatingWriterRejectsCurrentLogFIFO(t *testing.T) {
 	}
 
 	_, err := newCalendarRotatingWriterWithClock(dir, logFilePrefix, 2, func() time.Time {
-		return time.Date(2026, 5, 21, 10, 0, 0, 0, time.Local)
+		return time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
 	})
 	if err == nil {
 		t.Fatal("expected current log FIFO to be rejected")

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -310,7 +311,7 @@ func parseFamilies(values []string) (app.Families, error) {
 		}
 	}
 	if !families.IPv4 && !families.IPv6 {
-		return app.Families{}, fmt.Errorf("at least one family is required")
+		return app.Families{}, errors.New("at least one family is required")
 	}
 	return families, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestParseLogLevel(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		value string
@@ -27,6 +28,7 @@ func TestParseLogLevel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			level, ok := parseLogLevel(tt.value)
 			if level != tt.level {
 				t.Fatalf("expected level %v, got %v", tt.level, level)
@@ -39,6 +41,7 @@ func TestParseLogLevel(t *testing.T) {
 }
 
 func TestParseLogRetentionDays(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		value string
@@ -55,6 +58,7 @@ func TestParseLogRetentionDays(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			days, ok := parseLogRetentionDays(tt.value)
 			if days != tt.days {
 				t.Fatalf("expected days %d, got %d", tt.days, days)
@@ -202,6 +206,7 @@ jobs:
 }
 
 func TestJobOverridesOnlySelectedUpdater(t *testing.T) {
+	t.Parallel()
 	overrides, err := jobOverrides(config.Job{
 		Provider: "ip_service",
 		Updater:  "duckdns",
@@ -225,6 +230,7 @@ func TestJobOverridesOnlySelectedUpdater(t *testing.T) {
 }
 
 func TestJobOverridesClearInheritedZone(t *testing.T) {
+	t.Parallel()
 	overrides, err := jobOverrides(config.Job{
 		Provider: "ip_service",
 		Updater:  "cloudflare",

--- a/main_test.go
+++ b/main_test.go
@@ -361,7 +361,7 @@ func writeTempConfig(t *testing.T, content string) string {
 	t.Helper()
 
 	path := filepath.Join(t.TempDir(), "uddns.yaml")
-	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	return path

--- a/notifier/discord/discord.go
+++ b/notifier/discord/discord.go
@@ -133,14 +133,11 @@ func (d *Discord) Notify(ctx context.Context, notification notifier.Notification
 		return d.redactError(err)
 	}
 
-	switch resp.StatusCode() {
-	case http.StatusOK, http.StatusNoContent:
-		return nil
-	case http.StatusTooManyRequests:
-		return d.redactError(fmt.Errorf("Discord API request failed, rate limited, retry after %s", resp.Header().Get("Retry-After")))
-	}
 	if resp.IsSuccess() {
 		return nil
+	}
+	if resp.StatusCode() == http.StatusTooManyRequests {
+		return d.redactError(fmt.Errorf("Discord API request failed, rate limited, retry after %s", resp.Header().Get("Retry-After")))
 	}
 
 	apiResp := apiResponse{}

--- a/notifier/discord/discord.go
+++ b/notifier/discord/discord.go
@@ -3,6 +3,7 @@ package discord
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -64,14 +65,14 @@ func init() {
 
 func New(config *Discord) (discord *Discord, err error) {
 	if config == nil {
-		return nil, fmt.Errorf("Discord config is nil")
+		return nil, errors.New("Discord config is nil")
 	}
 	if config.URL != "" && (config.ID != "" || config.Token != "") {
-		return nil, fmt.Errorf("Discord config must either provide url or id and token, not a combination")
+		return nil, errors.New("Discord config must either provide url or id and token, not a combination")
 	}
 	if config.URL == "" {
 		if config.ID == "" || config.Token == "" {
-			return nil, fmt.Errorf("Discord config must provide url or id and token")
+			return nil, errors.New("Discord config must provide url or id and token")
 		}
 		config.URL = fmt.Sprintf("https://discord.com/api/webhooks/%s/%s", config.ID, config.Token)
 	}

--- a/notifier/discord/discord_test.go
+++ b/notifier/discord/discord_test.go
@@ -79,6 +79,7 @@ func TestClientBaseURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			client, err := New(tt.config)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("New() error = %v, wantErr %v", err, tt.wantErr)
@@ -97,6 +98,7 @@ func TestClientBaseURL(t *testing.T) {
 }
 
 func TestNotifyRedactTokenFromTransportError(t *testing.T) {
+	t.Parallel()
 	token := "discord+/token =secret"
 	discord, err := New(&Discord{
 		ID:    "123456",
@@ -115,6 +117,7 @@ func TestNotifyRedactTokenFromTransportError(t *testing.T) {
 }
 
 func TestNotifyRedactsTokenFromURLTransportError(t *testing.T) {
+	t.Parallel()
 	token := "discord-webhook-token"
 	discord, err := New(&Discord{
 		URL: "https://discord.com/api/webhooks/123456/" + token,
@@ -132,6 +135,7 @@ func TestNotifyRedactsTokenFromURLTransportError(t *testing.T) {
 }
 
 func TestNotifyDiscordAPIResponse(t *testing.T) {
+	t.Parallel()
 	token := "discord+/token =secret"
 	tests := []struct {
 		name       string
@@ -167,6 +171,7 @@ func TestNotifyDiscordAPIResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tt.statusCode)
@@ -191,6 +196,7 @@ func TestNotifyDiscordAPIResponse(t *testing.T) {
 }
 
 func TestNotifyCancelsInFlightRequest(t *testing.T) {
+	t.Parallel()
 	requestStarted := make(chan struct{})
 	releaseRequest := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/notifier/telegram/telegram.go
+++ b/notifier/telegram/telegram.go
@@ -3,6 +3,7 @@ package telegram
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -49,10 +50,10 @@ func init() {
 
 func New(config *Telegram) (*Telegram, error) {
 	if config == nil {
-		return nil, fmt.Errorf("Telegram config is nil")
+		return nil, errors.New("Telegram config is nil")
 	}
 	if config.Token == "" || config.ChatID == "" {
-		return nil, fmt.Errorf("missing required fields")
+		return nil, errors.New("missing required fields")
 	}
 
 	var proxy *url.URL

--- a/notifier/telegram/telegram_test.go
+++ b/notifier/telegram/telegram_test.go
@@ -25,6 +25,7 @@ func (f failingTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 }
 
 func TestHTTPClientTimeout(t *testing.T) {
+	t.Parallel()
 	client := newHTTPClient("token", nil)
 	if got := client.GetClient().Timeout; got != requestTimeout {
 		t.Fatalf("expected Telegram request timeout %s, got %s", requestTimeout, got)
@@ -35,6 +36,7 @@ func TestHTTPClientTimeout(t *testing.T) {
 }
 
 func TestNewValidatesProxyURLWithoutExposingCredentials(t *testing.T) {
+	t.Parallel()
 	_, err := New(&Telegram{
 		Token:  "token",
 		ChatID: "123456",
@@ -59,6 +61,7 @@ func TestNewValidatesProxyURLWithoutExposingCredentials(t *testing.T) {
 }
 
 func TestNotifyRedactsTokenFromTransportError(t *testing.T) {
+	t.Parallel()
 	token := "telegram+/token =secret"
 	telegram := &Telegram{
 		Token:  token,
@@ -76,6 +79,7 @@ func TestNotifyRedactsTokenFromTransportError(t *testing.T) {
 }
 
 func TestNotifyChecksTelegramAPIResponse(t *testing.T) {
+	t.Parallel()
 	token := "telegram+/token =secret"
 	tests := []struct {
 		name       string
@@ -104,6 +108,7 @@ func TestNotifyChecksTelegramAPIResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tt.statusCode)
@@ -128,6 +133,7 @@ func TestNotifyChecksTelegramAPIResponse(t *testing.T) {
 }
 
 func TestNotifyCancelsInFlightRequest(t *testing.T) {
+	t.Parallel()
 	requestStarted := make(chan struct{})
 	releaseRequest := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/provider/ip_service/ip_service.go
+++ b/provider/ip_service/ip_service.go
@@ -77,7 +77,7 @@ func init() {
 			return nil, err
 		}
 		if len(cfg) == 0 {
-			return nil, fmt.Errorf("no IP service names provided")
+			return nil, errors.New("no IP service names provided")
 		}
 		for _, name := range cfg {
 			if _, ok := SERVICES[name]; !ok {
@@ -90,7 +90,7 @@ func init() {
 
 func New(names *ServiceNames) (*IpService, error) {
 	if names == nil {
-		return nil, fmt.Errorf("IP service names are nil")
+		return nil, errors.New("IP service names are nil")
 	}
 	client4 := createClient("tcp4")
 	client6 := createClient("tcp6")
@@ -124,7 +124,7 @@ func createClient(network string) *resty.Client {
 func sameOriginHTTPSRedirectPolicy(maxRedirects int) resty.RedirectPolicy {
 	return resty.RedirectPolicyFunc(func(req *http.Request, via []*http.Request) error {
 		if len(via) == 0 {
-			return fmt.Errorf("redirect rejected: missing original request")
+			return errors.New("redirect rejected: missing original request")
 		}
 		if len(via) > maxRedirects {
 			return fmt.Errorf("redirect rejected: stopped after %d redirects", maxRedirects)
@@ -132,7 +132,7 @@ func sameOriginHTTPSRedirectPolicy(maxRedirects int) resty.RedirectPolicy {
 
 		origin := via[0].URL
 		if !strings.EqualFold(origin.Scheme, "https") || !strings.EqualFold(req.URL.Scheme, origin.Scheme) {
-			return fmt.Errorf("redirect rejected: scheme must remain HTTPS")
+			return errors.New("redirect rejected: scheme must remain HTTPS")
 		}
 		if !strings.EqualFold(req.URL.Host, origin.Host) {
 			return fmt.Errorf("redirect rejected: host must remain %q", origin.Host)
@@ -143,7 +143,7 @@ func sameOriginHTTPSRedirectPolicy(maxRedirects int) resty.RedirectPolicy {
 
 func (i *IpService) GetIPs(ctx context.Context, families provider.FamilyRequest) (*provider.IpResult, error) {
 	if !families.IPv4 && !families.IPv6 {
-		return nil, fmt.Errorf("no IP families requested")
+		return nil, errors.New("no IP families requested")
 	}
 	result := &provider.IpResult{}
 	var failures []error
@@ -172,7 +172,7 @@ func (i *IpService) GetIPs(ctx context.Context, families provider.FamilyRequest)
 
 	if result.IPv4 == "" && result.IPv6 == "" {
 		if len(failures) == 0 {
-			failures = append(failures, fmt.Errorf("failed to get requested IP addresses"))
+			failures = append(failures, errors.New("failed to get requested IP addresses"))
 		}
 		return nil, errors.Join(failures...)
 	}

--- a/provider/ip_service/ip_service.go
+++ b/provider/ip_service/ip_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"net/netip"
@@ -13,23 +14,26 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
+
 	"github.com/we11adam/uddns/internal/redact"
 	"github.com/we11adam/uddns/internal/restyretry"
 	"github.com/we11adam/uddns/provider"
 )
-
-var SERVICES = map[string]string{
-	"ip.fm":       "https://ip.fm/myip",
-	"ip.sb":       "https://ip.sb",
-	"ifconfig.me": "https://ifconfig.me",
-	"3322.org":    "https://members.3322.org/dyndns/getip",
-}
 
 const (
 	maxServiceRedirects = 3
 	responseBodyLimit   = 4 << 10
 	requestTimeout      = 5 * time.Second
 )
+
+func defaultServiceUrls() map[string]string {
+	return map[string]string{
+		"ip.fm":       "https://ip.fm/myip",
+		"ip.sb":       "https://ip.sb",
+		"ifconfig.me": "https://ifconfig.me",
+		"3322.org":    "https://members.3322.org/dyndns/getip",
+	}
+}
 
 var (
 	publicIPv6Prefix  = netip.MustParsePrefix("2000::/3")
@@ -62,7 +66,8 @@ type ServiceNames []string
 type IpService struct {
 	client4 *resty.Client
 	client6 *resty.Client
-	names   *ServiceNames
+	urls    map[string]string
+	names   ServiceNames
 }
 
 func init() {
@@ -76,30 +81,28 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		if len(cfg) == 0 {
-			return nil, errors.New("no IP service names provided")
-		}
-		for _, name := range cfg {
-			if _, ok := SERVICES[name]; !ok {
-				return nil, fmt.Errorf("unsupported IP service %q; supported services: %s", name, strings.Join(supportedServiceNames(), ", "))
-			}
-		}
-		return New(&cfg)
+		return New(cfg)
 	})
 }
 
-func New(names *ServiceNames) (*IpService, error) {
-	if names == nil {
-		return nil, errors.New("IP service names are nil")
+func New(names ServiceNames) (*IpService, error) {
+	if len(names) == 0 {
+		return nil, errors.New("no IP service names provided")
 	}
-	client4 := createClient("tcp4")
-	client6 := createClient("tcp6")
-
-	return &IpService{
-		client4: client4,
-		client6: client6,
+	ipService := &IpService{
+		client4: createClient("tcp4"),
+		client6: createClient("tcp6"),
+		urls:    defaultServiceUrls(),
 		names:   names,
-	}, nil
+	}
+
+	for _, name := range names {
+		if _, ok := ipService.urls[name]; !ok {
+			return nil, fmt.Errorf("unsupported IP service %q; supported services: %s", name, strings.Join(slices.Collect(maps.Keys(ipService.urls)), ", "))
+		}
+	}
+
+	return ipService, nil
 }
 
 func createClient(network string) *resty.Client {
@@ -182,11 +185,11 @@ func (i *IpService) GetIPs(ctx context.Context, families provider.FamilyRequest)
 
 func (i *IpService) getIP(ctx context.Context, client *resty.Client, family string) (string, error) {
 	var failures []error
-	for _, name := range *i.names {
+	for _, name := range i.names {
 		if err := ctx.Err(); err != nil {
 			return "", err
 		}
-		serviceURL, ok := SERVICES[name]
+		serviceURL, ok := i.urls[name]
 		if !ok {
 			failures = append(failures, fmt.Errorf("IP service %q (%s) is not registered", name, family))
 			continue
@@ -262,13 +265,4 @@ func isPublicRoutable(addr netip.Addr) bool {
 		}
 	}
 	return true
-}
-
-func supportedServiceNames() []string {
-	names := make([]string, 0, len(SERVICES))
-	for name := range SERVICES {
-		names = append(names, name)
-	}
-	slices.Sort(names)
-	return names
 }

--- a/provider/ip_service/ip_service.go
+++ b/provider/ip_service/ip_service.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -269,6 +269,6 @@ func supportedServiceNames() []string {
 	for name := range SERVICES {
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	return names
 }

--- a/provider/ip_service/ip_service_test.go
+++ b/provider/ip_service/ip_service_test.go
@@ -24,8 +24,10 @@ func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) 
 }
 
 func TestServicesUseHTTPS(t *testing.T) {
+	t.Parallel()
 	for name, serviceURL := range SERVICES {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			parsed, err := url.Parse(serviceURL)
 			if err != nil {
 				t.Fatalf("parse service URL %q: %v", serviceURL, err)
@@ -38,12 +40,14 @@ func TestServicesUseHTTPS(t *testing.T) {
 }
 
 func TestNewRejectsNilServiceNames(t *testing.T) {
+	t.Parallel()
 	if _, err := New(nil); err == nil {
 		t.Fatal("expected nil service names to be rejected")
 	}
 }
 
 func TestServiceRedirectPolicy(t *testing.T) {
+	t.Parallel()
 	parseURL := func(rawURL string) *url.URL {
 		t.Helper()
 		parsed, err := url.Parse(rawURL)
@@ -100,6 +104,7 @@ func TestServiceRedirectPolicy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := checkRedirect(request(tt.target), tt.via)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("redirect policy error = %v, wantErr %v", err, tt.wantErr)
@@ -109,6 +114,7 @@ func TestServiceRedirectPolicy(t *testing.T) {
 }
 
 func TestServiceClientLimitsResponseBodies(t *testing.T) {
+	t.Parallel()
 	client := createClient("tcp4")
 	if client.ResponseBodyLimit != responseBodyLimit {
 		t.Fatalf("response body limit = %d, want %d", client.ResponseBodyLimit, responseBodyLimit)
@@ -116,6 +122,7 @@ func TestServiceClientLimitsResponseBodies(t *testing.T) {
 }
 
 func TestServiceClientRetryPolicy(t *testing.T) {
+	t.Parallel()
 	client := createClient("tcp4")
 	if client.RetryCount != restyretry.MaxRetries {
 		t.Fatalf("retry count = %d, want %d", client.RetryCount, restyretry.MaxRetries)
@@ -126,6 +133,7 @@ func TestServiceClientRetryPolicy(t *testing.T) {
 }
 
 func TestGetIPsRetriesTransientFailures(t *testing.T) {
+	t.Parallel()
 	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		switch attempts.Add(1) {
@@ -154,6 +162,7 @@ func TestGetIPsRetriesTransientFailures(t *testing.T) {
 }
 
 func TestGetIPsDoesNotRetryPermanentClientError(t *testing.T) {
+	t.Parallel()
 	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		attempts.Add(1)
@@ -172,6 +181,7 @@ func TestGetIPsDoesNotRetryPermanentClientError(t *testing.T) {
 }
 
 func TestGetIPsJoinsRedactedErrorsWhenAllServicesFail(t *testing.T) {
+	t.Parallel()
 	const (
 		firstName    = "first.test"
 		secondName   = "second.test"
@@ -220,6 +230,7 @@ func TestGetIPsJoinsRedactedErrorsWhenAllServicesFail(t *testing.T) {
 }
 
 func TestGetIPsReturnsFirstSuccessAfterEarlierFailure(t *testing.T) {
+	t.Parallel()
 	const (
 		firstName  = "first.test"
 		secondName = "second.test"
@@ -282,6 +293,7 @@ func setTestServices(t *testing.T, services map[string]string) {
 }
 
 func TestGetIPsStopsRetriesWhenContextIsCanceled(t *testing.T) {
+	t.Parallel()
 	var attempts atomic.Int32
 	firstResponse := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -347,6 +359,7 @@ func testIPService(t *testing.T, serviceURL string) *IpService {
 }
 
 func TestGetIPsCancelsInFlightRequest(t *testing.T) {
+	t.Parallel()
 	requestStarted := make(chan struct{})
 	client := createClient("tcp4")
 	client.SetTransport(roundTripFunc(func(request *http.Request) (*http.Response, error) {
@@ -381,6 +394,7 @@ func TestGetIPsCancelsInFlightRequest(t *testing.T) {
 }
 
 func TestGetIPsRequestsOnlySelectedFamilies(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		families  provider.FamilyRequest
@@ -404,6 +418,7 @@ func TestGetIPsRequestsOnlySelectedFamilies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			calls := [2]int{}
 			client4 := createClient("tcp4")
 			client4.SetTransport(ipResponseTransport(&calls[0], "8.8.8.8"))
@@ -457,6 +472,7 @@ func (c testConfig) UnmarshalKey(_ string, rawVal any) error {
 }
 
 func TestGetProviderRejectsUnsupportedService(t *testing.T) {
+	t.Parallel()
 	_, _, err := provider.GetProvider(testConfig{services: ServiceNames{"missing"}})
 	if err == nil {
 		t.Fatal("expected unsupported service error")
@@ -467,6 +483,7 @@ func TestGetProviderRejectsUnsupportedService(t *testing.T) {
 }
 
 func TestIsValidIPFamily(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		ip     string
@@ -503,6 +520,7 @@ func TestIsValidIPFamily(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := isValidIPFamily(tt.ip, tt.family); got != tt.want {
 				t.Fatalf("isValidIPFamily(%q, %q) = %v, want %v", tt.ip, tt.family, got, tt.want)
 			}

--- a/provider/ip_service/ip_service_test.go
+++ b/provider/ip_service/ip_service_test.go
@@ -25,7 +25,7 @@ func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) 
 
 func TestServicesUseHTTPS(t *testing.T) {
 	t.Parallel()
-	for name, serviceURL := range SERVICES {
+	for name, serviceURL := range defaultServiceUrls() {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			parsed, err := url.Parse(serviceURL)
@@ -190,7 +190,6 @@ func TestGetIPsJoinsRedactedErrorsWhenAllServicesFail(t *testing.T) {
 	)
 	firstURL := "https://first.invalid/ip?token=" + secret
 	secondURL := "https://second.invalid/ip"
-	setTestServices(t, map[string]string{firstName: firstURL, secondName: secondURL})
 
 	client := createClient("tcp4")
 	client.SetRetryCount(0)
@@ -209,8 +208,12 @@ func TestGetIPsJoinsRedactedErrorsWhenAllServicesFail(t *testing.T) {
 			return nil, fmt.Errorf("unexpected request host %q", request.URL.Host)
 		}
 	}))
-	names := ServiceNames{firstName, secondName}
-	service := &IpService{client4: client, client6: createClient("tcp6"), names: &names}
+	service := &IpService{
+		client4: client,
+		client6: createClient("tcp6"),
+		urls:    map[string]string{firstName: firstURL, secondName: secondURL},
+		names:   ServiceNames{firstName, secondName},
+	}
 
 	_, err := service.GetIPs(context.Background(), provider.FamilyRequest{IPv4: true})
 	if err == nil {
@@ -235,10 +238,6 @@ func TestGetIPsReturnsFirstSuccessAfterEarlierFailure(t *testing.T) {
 		firstName  = "first.test"
 		secondName = "second.test"
 	)
-	setTestServices(t, map[string]string{
-		firstName:  "https://first.invalid/ip",
-		secondName: "https://second.invalid/ip",
-	})
 
 	client := createClient("tcp4")
 	client.SetRetryCount(0)
@@ -258,8 +257,15 @@ func TestGetIPsReturnsFirstSuccessAfterEarlierFailure(t *testing.T) {
 			Request:    request,
 		}, nil
 	}))
-	names := ServiceNames{firstName, secondName}
-	service := &IpService{client4: client, client6: createClient("tcp6"), names: &names}
+	service := &IpService{
+		client4: client,
+		client6: createClient("tcp6"),
+		urls: map[string]string{
+			firstName:  "https://first.invalid/ip",
+			secondName: "https://second.invalid/ip",
+		},
+		names: ServiceNames{firstName, secondName},
+	}
 
 	result, err := service.GetIPs(context.Background(), provider.FamilyRequest{IPv4: true})
 	if err != nil {
@@ -271,25 +277,6 @@ func TestGetIPsReturnsFirstSuccessAfterEarlierFailure(t *testing.T) {
 	if got, want := strings.Join(calls, ","), "first.invalid,second.invalid"; got != want {
 		t.Fatalf("request order = %q, want %q", got, want)
 	}
-}
-
-func setTestServices(t *testing.T, services map[string]string) {
-	t.Helper()
-	previous := make(map[string]string, len(services))
-	existed := make(map[string]bool, len(services))
-	for name, serviceURL := range services {
-		previous[name], existed[name] = SERVICES[name]
-		SERVICES[name] = serviceURL
-	}
-	t.Cleanup(func() {
-		for name := range services {
-			if existed[name] {
-				SERVICES[name] = previous[name]
-			} else {
-				delete(SERVICES, name)
-			}
-		}
-	})
 }
 
 func TestGetIPsStopsRetriesWhenContextIsCanceled(t *testing.T) {
@@ -341,34 +328,28 @@ func TestGetIPsStopsRetriesWhenContextIsCanceled(t *testing.T) {
 func testIPService(t *testing.T, serviceURL string) *IpService {
 	t.Helper()
 	const name = "test.local"
-	previous, existed := SERVICES[name]
-	SERVICES[name] = serviceURL
-	t.Cleanup(func() {
-		if existed {
-			SERVICES[name] = previous
-		} else {
-			delete(SERVICES, name)
-		}
-	})
-	names := ServiceNames{name}
-	service, err := New(&names)
-	if err != nil {
-		t.Fatalf("create IP service: %v", err)
+	return &IpService{
+		client4: createClient("tcp4"),
+		client6: createClient("tcp6"),
+		urls:    map[string]string{name: serviceURL},
+		names:   []string{name},
 	}
-	return service
 }
 
 func TestGetIPsCancelsInFlightRequest(t *testing.T) {
 	t.Parallel()
+	service, err := New(ServiceNames{"ip.fm"})
+	if err != nil {
+		t.Fatalf("failed to create IpService: %v", err)
+	}
 	requestStarted := make(chan struct{})
-	client := createClient("tcp4")
-	client.SetTransport(roundTripFunc(func(request *http.Request) (*http.Response, error) {
+	service.client4 = createClient("tcp4")
+	service.client4.SetTransport(roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		close(requestStarted)
 		<-request.Context().Done()
 		return nil, request.Context().Err()
 	}))
-	names := ServiceNames{"ip.fm"}
-	service := &IpService{client4: client, client6: createClient("tcp6"), names: &names}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
@@ -419,13 +400,16 @@ func TestGetIPsRequestsOnlySelectedFamilies(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
+			service, err := New(ServiceNames{"ip.fm"})
+			if err != nil {
+				t.Fatalf("failed to create IpService: %v", err)
+			}
 			calls := [2]int{}
-			client4 := createClient("tcp4")
-			client4.SetTransport(ipResponseTransport(&calls[0], "8.8.8.8"))
-			client6 := createClient("tcp6")
-			client6.SetTransport(ipResponseTransport(&calls[1], "2606:4700:4700::1111"))
-			names := ServiceNames{"ip.fm"}
-			service := &IpService{client4: client4, client6: client6, names: &names}
+			service.client4 = createClient("tcp4")
+			service.client4.SetTransport(ipResponseTransport(&calls[0], "8.8.8.8"))
+			service.client6 = createClient("tcp6")
+			service.client6.SetTransport(ipResponseTransport(&calls[1], "2606:4700:4700::1111"))
 
 			result, err := service.GetIPs(context.Background(), tt.families)
 			if err != nil {

--- a/provider/ips.go
+++ b/provider/ips.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"errors"
 	"fmt"
 	"net/netip"
 	"strings"
@@ -8,14 +9,14 @@ import (
 
 func (r *IpResult) Validate() error {
 	if r == nil {
-		return fmt.Errorf("IP result is nil")
+		return errors.New("IP result is nil")
 	}
 
 	r.IPv4 = strings.TrimSpace(r.IPv4)
 	r.IPv6 = strings.TrimSpace(r.IPv6)
 
 	if r.IPv4 == "" && r.IPv6 == "" {
-		return fmt.Errorf("no IP addresses found")
+		return errors.New("no IP addresses found")
 	}
 	if r.IPv4 != "" {
 		addr, err := netip.ParseAddr(r.IPv4)

--- a/provider/ips_test.go
+++ b/provider/ips_test.go
@@ -3,6 +3,7 @@ package provider
 import "testing"
 
 func TestIpResultValidate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		result   *IpResult
@@ -36,6 +37,7 @@ func TestIpResultValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := tt.result.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("expected wantErr=%v, got err=%v", tt.wantErr, err)
@@ -51,6 +53,7 @@ func TestIpResultValidate(t *testing.T) {
 }
 
 func TestIPFamilyValidationRejectsMappedIPv6(t *testing.T) {
+	t.Parallel()
 	mapped := "::ffff:192.0.2.10"
 	if IsValidIPv4(mapped) {
 		t.Fatalf("expected IPv4-mapped IPv6 %q to be rejected as IPv4", mapped)

--- a/provider/netif/netif.go
+++ b/provider/netif/netif.go
@@ -2,6 +2,7 @@ package netif
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -30,7 +31,7 @@ func init() {
 			return nil, err
 		}
 		if cfg.Name == "" {
-			return nil, fmt.Errorf("missing network interface name")
+			return nil, errors.New("missing network interface name")
 		}
 		return New(&cfg)
 	})
@@ -45,7 +46,7 @@ func newNetif(
 	interfaceByName func(string) (*net.Interface, error),
 ) (*Netif, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("network interface config is nil")
+		return nil, errors.New("network interface config is nil")
 	}
 	if _, err := interfaceByName(cfg.Name); err != nil {
 		return nil, err
@@ -58,7 +59,7 @@ func newNetif(
 
 func (n *Netif) GetIPs(ctx context.Context, families provider.FamilyRequest) (*provider.IpResult, error) {
 	if !families.IPv4 && !families.IPv6 {
-		return nil, fmt.Errorf("no IP families requested")
+		return nil, errors.New("no IP families requested")
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/provider/netif/netif_test.go
+++ b/provider/netif/netif_test.go
@@ -11,12 +11,14 @@ import (
 var allFamilies = provider.FamilyRequest{IPv4: true, IPv6: true}
 
 func TestNewRejectsNilConfig(t *testing.T) {
+	t.Parallel()
 	if _, err := New(nil); err == nil {
 		t.Fatal("expected nil config to be rejected")
 	}
 }
 
 func TestGetIPsResolvesInterfaceByNameOnEveryCall(t *testing.T) {
+	t.Parallel()
 	const name = "pppoe0"
 	lookupErr := errors.New("interface temporarily unavailable")
 	lookups := 0
@@ -45,6 +47,7 @@ func TestGetIPsResolvesInterfaceByNameOnEveryCall(t *testing.T) {
 }
 
 func TestSelectPublishableIPs(t *testing.T) {
+	t.Parallel()
 	addrs := []net.Addr{
 		ipNet("127.0.0.1/8"),
 		ipNet("169.254.10.20/16"),
@@ -71,6 +74,7 @@ func TestSelectPublishableIPs(t *testing.T) {
 }
 
 func TestSelectPublishableIPsIsIndependentOfAddressOrder(t *testing.T) {
+	t.Parallel()
 	forward := []net.Addr{
 		ipNet("192.168.1.20/24"),
 		ipNet("10.0.0.20/8"),
@@ -88,6 +92,7 @@ func TestSelectPublishableIPsIsIndependentOfAddressOrder(t *testing.T) {
 }
 
 func TestSelectPublishableIPsFallsBackToPrivateAddresses(t *testing.T) {
+	t.Parallel()
 	result := selectPublishableIPs([]net.Addr{
 		ipNet("192.168.1.20/24"),
 		ipNet("10.0.0.20/8"),
@@ -103,6 +108,7 @@ func TestSelectPublishableIPsFallsBackToPrivateAddresses(t *testing.T) {
 }
 
 func TestSelectPublishableIPsReturnsEmptyWithoutGlobalUnicast(t *testing.T) {
+	t.Parallel()
 	result := selectPublishableIPs([]net.Addr{
 		ipNet("127.0.0.1/8"),
 		ipNet("169.254.10.20/16"),
@@ -115,6 +121,7 @@ func TestSelectPublishableIPsReturnsEmptyWithoutGlobalUnicast(t *testing.T) {
 }
 
 func TestSelectPublishableIPsReturnsOnlyRequestedFamilies(t *testing.T) {
+	t.Parallel()
 	addrs := []net.Addr{
 		ipNet("198.51.100.20/24"),
 		ipNet("2001:db8::20/64"),
@@ -131,6 +138,7 @@ func TestSelectPublishableIPsReturnsOnlyRequestedFamilies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := selectPublishableIPs(addrs, tt.families)
 			if result.IPv4 != tt.want4 || result.IPv6 != tt.want6 {
 				t.Fatalf("result = %+v, want IPv4=%q IPv6=%q", result, tt.want4, tt.want6)

--- a/provider/routeros/routeros.go
+++ b/provider/routeros/routeros.go
@@ -3,6 +3,7 @@ package routeros
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -57,7 +58,7 @@ func init() {
 		}
 
 		if cfg.Username == "" || cfg.Endpoint == "" {
-			return nil, fmt.Errorf("missing required RouterOS fields")
+			return nil, errors.New("missing required RouterOS fields")
 		}
 		return New(&cfg)
 	})
@@ -96,7 +97,7 @@ func routerOSRestURL(endpoint string) (string, error) {
 
 func (r *RouterOS) GetIPs(ctx context.Context, families provider.FamilyRequest) (*provider.IpResult, error) {
 	if !families.IPv4 && !families.IPv6 {
-		return nil, fmt.Errorf("no IP families requested")
+		return nil, errors.New("no IP families requested")
 	}
 	var rfaces []rosInterface
 	if err := r.get(ctx, "/interface", &rfaces); err != nil {
@@ -142,7 +143,7 @@ func (r *RouterOS) GetIPs(ctx context.Context, families provider.FamilyRequest) 
 	}
 
 	if result.IPv4 == "" && result.IPv6 == "" {
-		return nil, fmt.Errorf("no IP address found")
+		return nil, errors.New("no IP address found")
 	}
 
 	return result, nil

--- a/provider/routeros/routeros_test.go
+++ b/provider/routeros/routeros_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestRouterOSRestURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		endpoint string
@@ -31,6 +32,7 @@ func TestRouterOSRestURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := routerOSRestURL(tt.endpoint)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("expected wantErr=%v, got err=%v", tt.wantErr, err)
@@ -46,6 +48,7 @@ func TestRouterOSRestURL(t *testing.T) {
 }
 
 func TestNewVerifiesTLSByDefault(t *testing.T) {
+	t.Parallel()
 	router, err := New(&Config{
 		Username: "admin",
 		Password: "secret",
@@ -68,6 +71,7 @@ func TestNewVerifiesTLSByDefault(t *testing.T) {
 }
 
 func TestNewAllowsExplicitInsecureTLS(t *testing.T) {
+	t.Parallel()
 	insecure := true
 	router, err := New(&Config{
 		Username: "admin",
@@ -89,6 +93,7 @@ func TestNewAllowsExplicitInsecureTLS(t *testing.T) {
 }
 
 func TestGetIPsRequestsOnlySelectedFamilies(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		families  provider.FamilyRequest
@@ -112,6 +117,7 @@ func TestGetIPsRequestsOnlySelectedFamilies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var paths []string
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 				paths = append(paths, request.URL.Path)
@@ -145,6 +151,7 @@ func TestGetIPsRequestsOnlySelectedFamilies(t *testing.T) {
 }
 
 func TestGetIPsSkipsDisabledAddresses(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch request.URL.Path {
@@ -177,6 +184,7 @@ func TestGetIPsSkipsDisabledAddresses(t *testing.T) {
 }
 
 func TestGetIPsRejectsOnlyDisabledAddresses(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch request.URL.Path {
@@ -197,6 +205,7 @@ func TestGetIPsRejectsOnlyDisabledAddresses(t *testing.T) {
 }
 
 func TestGetIPsReportsHTTPFailures(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		failureAt  string
@@ -231,6 +240,7 @@ func TestGetIPsReportsHTTPFailures(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			password := "router+/password =secret"
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 				if request.URL.Path == tt.failureAt {

--- a/selfupdate_command.go
+++ b/selfupdate_command.go
@@ -132,10 +132,7 @@ func printSelfUpdatePlan(
 	var message string
 	switch plan.Status {
 	case selfupdate.StatusDevelopment:
-		message = fmt.Sprintf(
-			"development build; latest stable version is %s",
-			plan.TargetVersion,
-		)
+		message = "development build; latest stable version is "+ plan.TargetVersion
 	case selfupdate.StatusNewerThanTarget:
 		message = fmt.Sprintf(
 			"installed version %s is newer than target %s",
@@ -149,7 +146,7 @@ func printSelfUpdatePlan(
 			plan.TargetVersion,
 		)
 	case selfupdate.StatusUpToDate:
-		message = fmt.Sprintf("up to date: %s", plan.TargetVersion)
+		message = "up to date: " + plan.TargetVersion
 	default:
 		return printSelfUpdateError(
 			stderr,

--- a/selfupdate_command.go
+++ b/selfupdate_command.go
@@ -132,7 +132,7 @@ func printSelfUpdatePlan(
 	var message string
 	switch plan.Status {
 	case selfupdate.StatusDevelopment:
-		message = "development build; latest stable version is "+ plan.TargetVersion
+		message = "development build; latest stable version is " + plan.TargetVersion
 	case selfupdate.StatusNewerThanTarget:
 		message = fmt.Sprintf(
 			"installed version %s is newer than target %s",

--- a/selfupdate_command_test.go
+++ b/selfupdate_command_test.go
@@ -53,6 +53,7 @@ func (f *fakeSelfUpdater) Rollback(context.Context) (selfupdate.Result, error) {
 }
 
 func TestRunSelfUpdateCheck(t *testing.T) {
+	t.Parallel()
 	fake := &fakeSelfUpdater{
 		plan: selfupdate.Plan{
 			CurrentVersion: "1.8.0",
@@ -83,6 +84,7 @@ func TestRunSelfUpdateCheck(t *testing.T) {
 }
 
 func TestRunSelfUpdateCheckStatuses(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		status selfupdate.Status
 		want   string
@@ -93,6 +95,7 @@ func TestRunSelfUpdateCheckStatuses(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(string(test.status), func(t *testing.T) {
+			t.Parallel()
 			fake := &fakeSelfUpdater{
 				plan: selfupdate.Plan{
 					CurrentVersion: "1.9.0",
@@ -112,6 +115,7 @@ func TestRunSelfUpdateCheckStatuses(t *testing.T) {
 }
 
 func TestRunSelfUpdateCheckJSON(t *testing.T) {
+	t.Parallel()
 	fake := &fakeSelfUpdater{
 		plan: selfupdate.Plan{
 			CurrentVersion: "1.8.0",
@@ -134,6 +138,7 @@ func TestRunSelfUpdateCheckJSON(t *testing.T) {
 }
 
 func TestRunSelfUpdateAppliesPlan(t *testing.T) {
+	t.Parallel()
 	fake := &fakeSelfUpdater{
 		plan: selfupdate.Plan{
 			CurrentVersion: "dev",
@@ -170,6 +175,7 @@ func TestRunSelfUpdateAppliesPlan(t *testing.T) {
 }
 
 func TestRunSelfUpdateAlreadyCurrent(t *testing.T) {
+	t.Parallel()
 	fake := &fakeSelfUpdater{
 		plan: selfupdate.Plan{Status: selfupdate.StatusUpToDate},
 		result: selfupdate.Result{
@@ -187,6 +193,7 @@ func TestRunSelfUpdateAlreadyCurrent(t *testing.T) {
 }
 
 func TestRunSelfUpdateRollback(t *testing.T) {
+	t.Parallel()
 	fake := &fakeSelfUpdater{
 		result: selfupdate.Result{
 			Changed:     true,
@@ -208,6 +215,7 @@ func TestRunSelfUpdateRollback(t *testing.T) {
 }
 
 func TestRunSelfUpdateJSONResult(t *testing.T) {
+	t.Parallel()
 	fake := &fakeSelfUpdater{
 		plan: selfupdate.Plan{Status: selfupdate.StatusUpdateAvailable},
 		result: selfupdate.Result{
@@ -230,6 +238,7 @@ func TestRunSelfUpdateJSONResult(t *testing.T) {
 }
 
 func TestRunSelfUpdateRejectsInvalidFlagCombinations(t *testing.T) {
+	t.Parallel()
 	tests := [][]string{
 		{"extra"},
 		{"--unknown"},
@@ -241,6 +250,7 @@ func TestRunSelfUpdateRejectsInvalidFlagCombinations(t *testing.T) {
 	}
 	for _, args := range tests {
 		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			t.Parallel()
 			factoryCalls := 0
 			var stdout bytes.Buffer
 			var stderr bytes.Buffer
@@ -267,6 +277,7 @@ func TestRunSelfUpdateRejectsInvalidFlagCombinations(t *testing.T) {
 }
 
 func TestRunSelfUpdateHelp(t *testing.T) {
+	t.Parallel()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	code := runSelfUpdateCommand(
@@ -285,6 +296,7 @@ func TestRunSelfUpdateHelp(t *testing.T) {
 }
 
 func TestRunSelfUpdateReportsOperationalErrors(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		fake *fakeSelfUpdater
@@ -306,6 +318,7 @@ func TestRunSelfUpdateReportsOperationalErrors(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, stderr, code := runFakeSelfUpdate(t, test.fake, test.args...)
 			if code != 1 {
 				t.Fatalf("expected operational error, got %d", code)
@@ -318,6 +331,7 @@ func TestRunSelfUpdateReportsOperationalErrors(t *testing.T) {
 }
 
 func TestRunSelfUpdateReportsFactoryAndPermissionErrors(t *testing.T) {
+	t.Parallel()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	code := runSelfUpdateCommand(
@@ -352,6 +366,7 @@ func TestRunSelfUpdateReportsFactoryAndPermissionErrors(t *testing.T) {
 }
 
 func TestRunSelfUpdateSuggestsSudoOnlyForLocalApplyPermissionErrors(t *testing.T) {
+	t.Parallel()
 	fake := &fakeSelfUpdater{
 		applyError: &selfupdate.LocalPermissionError{Err: os.ErrPermission},
 	}
@@ -374,6 +389,7 @@ func TestRunSelfUpdateSuggestsSudoOnlyForLocalApplyPermissionErrors(t *testing.T
 }
 
 func TestSelfUpdateOutputWriteFailures(t *testing.T) {
+	t.Parallel()
 	plan := selfupdate.Plan{
 		Status:        selfupdate.StatusUpdateAvailable,
 		TargetVersion: "v1.9.0",

--- a/updater/aliyun/aliyun_test.go
+++ b/updater/aliyun/aliyun_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/alibabacloud-go/tea/dara"
+
 	"github.com/we11adam/uddns/provider"
 )
 
@@ -458,7 +459,7 @@ func aliyunRequestParameters(request *http.Request) (url.Values, error) {
 
 func describeSubDomainRecordsResponse(total int64, pageNumber string, count int) string {
 	records := make([]string, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		records[i] = fmt.Sprintf(`{"RecordId":"%s-%d","Value":"192.0.2.10"}`, pageNumber, i)
 	}
 	return fmt.Sprintf(`{

--- a/updater/aliyun/aliyun_test.go
+++ b/updater/aliyun/aliyun_test.go
@@ -24,6 +24,7 @@ func (f httpClientFunc) Call(request *http.Request, transport *http.Transport) (
 }
 
 func TestNewUsesHTTPSAndTimeouts(t *testing.T) {
+	t.Parallel()
 	aliyun, err := New(&Config{
 		AccessKeyID:     "access-key-id",
 		AccessKeySecret: "access-key-secret",
@@ -51,12 +52,14 @@ func TestNewUsesHTTPSAndTimeouts(t *testing.T) {
 }
 
 func TestNewRejectsNilConfig(t *testing.T) {
+	t.Parallel()
 	if _, err := New(nil); err == nil {
 		t.Fatal("expected nil config to be rejected")
 	}
 }
 
 func TestBoundedHTTPClientLimitsResponseBody(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(response, strings.Repeat("x", responseBodyMax+1))
 	}))
@@ -85,6 +88,7 @@ func TestBoundedHTTPClientLimitsResponseBody(t *testing.T) {
 }
 
 func TestOperationsCheckContextBeforeRequest(t *testing.T) {
+	t.Parallel()
 	aliyun, err := New(&Config{
 		AccessKeyID:     "access-key-id",
 		AccessKeySecret: "access-key-secret",
@@ -97,6 +101,7 @@ func TestOperationsCheckContextBeforeRequest(t *testing.T) {
 	cancel()
 
 	t.Run("Update", func(t *testing.T) {
+		t.Parallel()
 		err := aliyun.Update(ctx, &provider.IpResult{IPv4: "192.0.2.1"})
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("expected canceled update, got %v", err)
@@ -104,6 +109,7 @@ func TestOperationsCheckContextBeforeRequest(t *testing.T) {
 	})
 
 	t.Run("Current", func(t *testing.T) {
+		t.Parallel()
 		_, err := aliyun.Current(ctx, provider.FamilyRequest{IPv4: true})
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("expected canceled read, got %v", err)
@@ -112,6 +118,7 @@ func TestOperationsCheckContextBeforeRequest(t *testing.T) {
 }
 
 func TestUpdateCancelsInFlightRequest(t *testing.T) {
+	t.Parallel()
 	aliyun, err := New(&Config{
 		AccessKeyID:     "access-key-id",
 		AccessKeySecret: "access-key-secret",
@@ -158,6 +165,7 @@ func TestUpdateCancelsInFlightRequest(t *testing.T) {
 }
 
 func TestDuplicateDNSRecordsAreReconciledAndMixedValuesTriggerRepair(t *testing.T) {
+	t.Parallel()
 	aliyun, err := New(&Config{
 		AccessKeyID:     "access-key-id",
 		AccessKeySecret: "access-key-secret",
@@ -245,6 +253,7 @@ func TestDuplicateDNSRecordsAreReconciledAndMixedValuesTriggerRepair(t *testing.
 }
 
 func TestListDNSRecordsPaginates(t *testing.T) {
+	t.Parallel()
 	aliyun := newTestAliyun(t)
 	var requestedPages []string
 	aliyun.client.HttpClient = httpClientFunc(func(request *http.Request, _ *http.Transport) (*http.Response, error) {
@@ -286,6 +295,7 @@ func TestListDNSRecordsPaginates(t *testing.T) {
 }
 
 func TestListDNSRecordsRejectsExcessivePages(t *testing.T) {
+	t.Parallel()
 	aliyun := newTestAliyun(t)
 	requests := 0
 	aliyun.client.HttpClient = httpClientFunc(func(request *http.Request, _ *http.Transport) (*http.Response, error) {
@@ -312,6 +322,7 @@ func TestListDNSRecordsRejectsExcessivePages(t *testing.T) {
 }
 
 func TestListDNSRecordsAllowsCompletePageLimit(t *testing.T) {
+	t.Parallel()
 	aliyun := newTestAliyun(t)
 	requests := 0
 	total := int64(recordPageSize * recordPageLimit)
@@ -337,6 +348,7 @@ func TestListDNSRecordsAllowsCompletePageLimit(t *testing.T) {
 }
 
 func TestCurrentRequestsOnlySelectedFamilies(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		families provider.FamilyRequest
@@ -360,6 +372,7 @@ func TestCurrentRequestsOnlySelectedFamilies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			aliyun, err := New(&Config{
 				AccessKeyID:     "access-key-id",
 				AccessKeySecret: "access-key-secret",

--- a/updater/aliyun/aliyun_test.go
+++ b/updater/aliyun/aliyun_test.go
@@ -25,14 +25,7 @@ func (f httpClientFunc) Call(request *http.Request, transport *http.Transport) (
 
 func TestNewUsesHTTPSAndTimeouts(t *testing.T) {
 	t.Parallel()
-	aliyun, err := New(&Config{
-		AccessKeyID:     "access-key-id",
-		AccessKeySecret: "access-key-secret",
-		Domain:          "ddns.example.com",
-	})
-	if err != nil {
-		t.Fatalf("create Aliyun updater: %v", err)
-	}
+	aliyun := newTestAliyun(t)
 
 	if got := dara.StringValue(aliyun.client.Protocol); got != "HTTPS" {
 		t.Fatalf("expected Aliyun API protocol HTTPS, got %q", got)
@@ -89,19 +82,12 @@ func TestBoundedHTTPClientLimitsResponseBody(t *testing.T) {
 
 func TestOperationsCheckContextBeforeRequest(t *testing.T) {
 	t.Parallel()
-	aliyun, err := New(&Config{
-		AccessKeyID:     "access-key-id",
-		AccessKeySecret: "access-key-secret",
-		Domain:          "ddns.example.com",
-	})
-	if err != nil {
-		t.Fatalf("create Aliyun updater: %v", err)
-	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-
 	t.Run("Update", func(t *testing.T) {
 		t.Parallel()
+		aliyun := newTestAliyun(t)
 		err := aliyun.Update(ctx, &provider.IpResult{IPv4: "192.0.2.1"})
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("expected canceled update, got %v", err)
@@ -110,6 +96,7 @@ func TestOperationsCheckContextBeforeRequest(t *testing.T) {
 
 	t.Run("Current", func(t *testing.T) {
 		t.Parallel()
+		aliyun := newTestAliyun(t)
 		_, err := aliyun.Current(ctx, provider.FamilyRequest{IPv4: true})
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("expected canceled read, got %v", err)
@@ -119,14 +106,7 @@ func TestOperationsCheckContextBeforeRequest(t *testing.T) {
 
 func TestUpdateCancelsInFlightRequest(t *testing.T) {
 	t.Parallel()
-	aliyun, err := New(&Config{
-		AccessKeyID:     "access-key-id",
-		AccessKeySecret: "access-key-secret",
-		Domain:          "ddns.example.com",
-	})
-	if err != nil {
-		t.Fatalf("create Aliyun updater: %v", err)
-	}
+	aliyun := newTestAliyun(t)
 
 	requests := make(chan *http.Request, 1)
 	aliyun.client.HttpClient = httpClientFunc(func(request *http.Request, _ *http.Transport) (*http.Response, error) {
@@ -166,14 +146,7 @@ func TestUpdateCancelsInFlightRequest(t *testing.T) {
 
 func TestDuplicateDNSRecordsAreReconciledAndMixedValuesTriggerRepair(t *testing.T) {
 	t.Parallel()
-	aliyun, err := New(&Config{
-		AccessKeyID:     "access-key-id",
-		AccessKeySecret: "access-key-secret",
-		Domain:          "home.example.com",
-	})
-	if err != nil {
-		t.Fatalf("create Aliyun updater: %v", err)
-	}
+	aliyun := newTestAliyun(t)
 
 	updates := make(map[string]string)
 	aliyun.client.HttpClient = httpClientFunc(func(request *http.Request, _ *http.Transport) (*http.Response, error) {

--- a/updater/cloudflare/cloudflare.go
+++ b/updater/cloudflare/cloudflare.go
@@ -60,10 +60,10 @@ func init() {
 
 func New(config *Config) (*Cloudflare, error) {
 	if config == nil {
-		return nil, fmt.Errorf("Cloudflare config is nil")
+		return nil, errors.New("Cloudflare config is nil")
 	}
 	if config.Domain == "" {
-		return nil, fmt.Errorf("Cloudflare domain is not set in the configuration")
+		return nil, errors.New("Cloudflare domain is not set in the configuration")
 	}
 	domain, err := dnsname.Normalize(config.Domain)
 	if err != nil {
@@ -100,7 +100,7 @@ func New(config *Config) (*Cloudflare, error) {
 		slog.Debug("using API key and email for authentication", "updater", "cloudflare")
 		api, err = cloudflare.New(config.APIKey, config.Email, cloudflare.HTTPClient(httpClient))
 	} else {
-		return nil, fmt.Errorf("Cloudflare configuration error: either API token or both API key and email must be provided")
+		return nil, errors.New("Cloudflare configuration error: either API token or both API key and email must be provided")
 	}
 
 	if err != nil {

--- a/updater/cloudflare/cloudflare.go
+++ b/updater/cloudflare/cloudflare.go
@@ -317,7 +317,7 @@ func (c *Cloudflare) updateDNSRecord(ctx context.Context, recordType, ip string)
 			Name:    domain,
 			Content: ip,
 			TTL:     defaultTTL,
-			Proxied: cloudflare.BoolPtr(false),
+			Proxied: new(false),
 		}
 
 		_, err := c.client.CreateDNSRecord(ctx, cloudflare.ZoneIdentifier(c.zoneID), createParams)

--- a/updater/cloudflare/cloudflare_test.go
+++ b/updater/cloudflare/cloudflare_test.go
@@ -55,19 +55,14 @@ func TestNewRejectsNilConfig(t *testing.T) {
 
 func TestHTTPClientSupportsCustomDefaultTransport(t *testing.T) {
 	t.Parallel()
-	original := http.DefaultTransport
-	t.Cleanup(func() { http.DefaultTransport = original })
-
-	custom := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+	client := newHTTPClient(nil)
+	client.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusNoContent,
 			Body:       http.NoBody,
 			Request:    request,
 		}, nil
 	})
-	http.DefaultTransport = custom
-
-	client := newHTTPClient(nil)
 	request, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	if err != nil {
 		t.Fatalf("create request: %v", err)

--- a/updater/cloudflare/cloudflare_test.go
+++ b/updater/cloudflare/cloudflare_test.go
@@ -36,6 +36,7 @@ func (b *trackingBody) Close() error {
 }
 
 func TestHTTPClientHasRequestTimeout(t *testing.T) {
+	t.Parallel()
 	client := newHTTPClient(nil)
 	if client.Timeout != requestTimeout {
 		t.Fatalf("expected timeout %s, got %s", requestTimeout, client.Timeout)
@@ -46,12 +47,14 @@ func TestHTTPClientHasRequestTimeout(t *testing.T) {
 }
 
 func TestNewRejectsNilConfig(t *testing.T) {
+	t.Parallel()
 	if _, err := New(nil); err == nil {
 		t.Fatal("expected nil config to be rejected")
 	}
 }
 
 func TestHTTPClientSupportsCustomDefaultTransport(t *testing.T) {
+	t.Parallel()
 	original := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = original })
 
@@ -80,8 +83,10 @@ func TestHTTPClientSupportsCustomDefaultTransport(t *testing.T) {
 }
 
 func TestRetryResponseTransportClosesRetryableResponseBody(t *testing.T) {
+	t.Parallel()
 	for _, statusCode := range []int{http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusServiceUnavailable} {
 		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			t.Parallel()
 			body := &trackingBody{reader: strings.NewReader("retry response")}
 			transport := retryResponseBodyClosingTransport{base: roundTripFunc(func(*http.Request) (*http.Response, error) {
 				return &http.Response{StatusCode: statusCode, Body: body}, nil
@@ -109,6 +114,7 @@ func TestRetryResponseTransportClosesRetryableResponseBody(t *testing.T) {
 }
 
 func TestRetryResponseTransportLimitsNonRetryableResponseBody(t *testing.T) {
+	t.Parallel()
 	body := &trackingBody{reader: strings.NewReader(strings.Repeat("x", responseBodyMax+1))}
 	transport := retryResponseBodyClosingTransport{base: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusBadRequest, Body: body}, nil
@@ -137,6 +143,7 @@ func TestRetryResponseTransportLimitsNonRetryableResponseBody(t *testing.T) {
 }
 
 func TestProxyLogValueRedactsCredentials(t *testing.T) {
+	t.Parallel()
 	proxy, err := url.Parse("http://user:secret@127.0.0.1:8080/path?token=hidden")
 	if err != nil {
 		t.Fatalf("parse proxy URL: %v", err)
@@ -149,6 +156,7 @@ func TestProxyLogValueRedactsCredentials(t *testing.T) {
 }
 
 func TestNewValidatesProxyURLWithoutExposingCredentials(t *testing.T) {
+	t.Parallel()
 	_, err := New(&Config{
 		APIToken: "token",
 		Domain:   "home.example.com",
@@ -173,6 +181,7 @@ func TestNewValidatesProxyURLWithoutExposingCredentials(t *testing.T) {
 }
 
 func TestDuplicateDNSRecordsAreReconciledAndMixedValuesTriggerRepair(t *testing.T) {
+	t.Parallel()
 	updated := make(map[string]string)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -243,6 +252,7 @@ func TestDuplicateDNSRecordsAreReconciledAndMixedValuesTriggerRepair(t *testing.
 }
 
 func TestCurrentRequestsOnlySelectedFamilies(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		families provider.FamilyRequest
@@ -266,6 +276,7 @@ func TestCurrentRequestsOnlySelectedFamilies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var requestedTypes []string
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 				if request.URL.Path != "/zones/zone-id/dns_records" {
@@ -314,6 +325,7 @@ func TestCurrentRequestsOnlySelectedFamilies(t *testing.T) {
 }
 
 func TestUpdateRefreshesStaleZoneID(t *testing.T) {
+	t.Parallel()
 	var staleLists, zoneLookups, freshLists, creates int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
@@ -358,6 +370,7 @@ func TestUpdateRefreshesStaleZoneID(t *testing.T) {
 }
 
 func TestCurrentRefreshesStaleZoneID(t *testing.T) {
+	t.Parallel()
 	var staleLists, zoneLookups, freshLists int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
@@ -396,6 +409,7 @@ func TestCurrentRefreshesStaleZoneID(t *testing.T) {
 }
 
 func TestStaleZoneIDRefreshRetriesOnlyOnce(t *testing.T) {
+	t.Parallel()
 	var staleLists, zoneLookups, freshLists int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
@@ -428,6 +442,7 @@ func TestStaleZoneIDRefreshRetriesOnlyOnce(t *testing.T) {
 }
 
 func TestZoneIDIsNotRefreshedForUnrelatedAPIErrors(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		statusCode int
@@ -441,6 +456,7 @@ func TestZoneIDIsNotRefreshedForUnrelatedAPIErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var recordLists, zoneLookups int
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 				switch request.URL.Path {
@@ -472,6 +488,7 @@ func TestZoneIDIsNotRefreshedForUnrelatedAPIErrors(t *testing.T) {
 }
 
 func TestZoneLookupUsesContext(t *testing.T) {
+	t.Parallel()
 	api, err := cloudflareapi.NewWithAPIToken("token", cloudflareapi.HTTPClient(&http.Client{}))
 	if err != nil {
 		t.Fatalf("create Cloudflare API client: %v", err)

--- a/updater/duckdns/duckdns.go
+++ b/updater/duckdns/duckdns.go
@@ -100,7 +100,6 @@ func (c *DuckDNS) updateIP(ctx context.Context, ip string) error {
 			"token":   c.config.Token,
 			"ip":      ip,
 		}).Get("/update")
-
 	if err != nil {
 		return redact.Error(err, c.config.Token)
 	}

--- a/updater/duckdns/duckdns.go
+++ b/updater/duckdns/duckdns.go
@@ -2,6 +2,7 @@ package duckdns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -43,7 +44,7 @@ func init() {
 			return nil, err
 		}
 		if cfg.Domain == "" || cfg.Token == "" {
-			return nil, fmt.Errorf("missing required DuckDNS fields")
+			return nil, errors.New("missing required DuckDNS fields")
 		}
 		return New(&cfg)
 	})
@@ -51,7 +52,7 @@ func init() {
 
 func New(cfg *Config) (*DuckDNS, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("DuckDNS config is nil")
+		return nil, errors.New("DuckDNS config is nil")
 	}
 	domain, err := dnsname.Normalize(cfg.Domain)
 	if err != nil {

--- a/updater/duckdns/duckdns_test.go
+++ b/updater/duckdns/duckdns_test.go
@@ -22,9 +22,11 @@ func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) 
 }
 
 func TestUpdateIPRedactsToken(t *testing.T) {
+	t.Parallel()
 	token := "duck+/token =secret"
 
 	t.Run("transport error", func(t *testing.T) {
+		t.Parallel()
 		duckDNS := mustNewDuckDNS(t, &Config{Domain: "home", Token: token})
 		duckDNS.httpclient.SetRetryCount(0)
 		duckDNS.httpclient.SetTransport(roundTripFunc(func(_ *http.Request) (*http.Response, error) {
@@ -39,6 +41,7 @@ func TestUpdateIPRedactsToken(t *testing.T) {
 	})
 
 	t.Run("response body", func(t *testing.T) {
+		t.Parallel()
 		duckDNS := mustNewDuckDNS(t, &Config{Domain: "home", Token: token})
 		duckDNS.httpclient.SetTransport(roundTripFunc(func(request *http.Request) (*http.Response, error) {
 			body := "invalid token " + token + " / " + url.QueryEscape(token)
@@ -59,6 +62,7 @@ func TestUpdateIPRedactsToken(t *testing.T) {
 }
 
 func TestUpdateIPRetriesTransientFailures(t *testing.T) {
+	t.Parallel()
 	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		switch attempts.Add(1) {
@@ -85,6 +89,7 @@ func TestUpdateIPRetriesTransientFailures(t *testing.T) {
 }
 
 func TestUpdateIPRequiresHTTP200AndOKBody(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		status       int
@@ -100,6 +105,7 @@ func TestUpdateIPRequiresHTTP200AndOKBody(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var attempts atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				attempts.Add(1)
@@ -128,6 +134,7 @@ func TestUpdateIPRequiresHTTP200AndOKBody(t *testing.T) {
 }
 
 func TestUpdateIPDoesNotRetryPermanentClientError(t *testing.T) {
+	t.Parallel()
 	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		attempts.Add(1)
@@ -148,6 +155,7 @@ func TestUpdateIPDoesNotRetryPermanentClientError(t *testing.T) {
 }
 
 func TestUpdateIPStopsRetriesWhenContextIsCanceled(t *testing.T) {
+	t.Parallel()
 	var attempts atomic.Int32
 	firstResponse := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -194,6 +202,7 @@ func TestUpdateIPStopsRetriesWhenContextIsCanceled(t *testing.T) {
 }
 
 func TestUpdateIPPropagatesContext(t *testing.T) {
+	t.Parallel()
 	type contextKey struct{}
 	key := contextKey{}
 	ctx := context.WithValue(context.Background(), key, "request-value")
@@ -216,6 +225,7 @@ func TestUpdateIPPropagatesContext(t *testing.T) {
 }
 
 func TestNewNormalizesAndValidatesDomain(t *testing.T) {
+	t.Parallel()
 	duckDNS := mustNewDuckDNS(t, &Config{Domain: " Home.DuckDNS.org. ", Token: "token"})
 	if duckDNS.config.Domain != "home.duckdns.org" {
 		t.Fatalf("domain = %q, want %q", duckDNS.config.Domain, "home.duckdns.org")
@@ -240,6 +250,7 @@ func TestNewNormalizesAndValidatesDomain(t *testing.T) {
 		"home/duckdns.org",
 	} {
 		t.Run(domain, func(t *testing.T) {
+			t.Parallel()
 			if _, err := New(&Config{Domain: domain, Token: "token"}); err == nil {
 				t.Fatalf("expected domain %q to be rejected", domain)
 			}

--- a/updater/lightdns/lightdns.go
+++ b/updater/lightdns/lightdns.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -105,7 +106,7 @@ func (c *LightDNS) updateIP(ctx context.Context, ip string) error {
 
 	body := string(resp.Body())
 
-	if resp.StatusCode() != 200 {
+	if resp.StatusCode() != http.StatusOK {
 		return fmt.Errorf("failed to update LightDNS DNS record: %s", redact.String(body, c.config.Key))
 	}
 

--- a/updater/lightdns/lightdns.go
+++ b/updater/lightdns/lightdns.go
@@ -2,6 +2,7 @@ package lightdns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -41,7 +42,7 @@ func init() {
 			return nil, err
 		}
 		if cfg.Domain == "" || cfg.Key == "" {
-			return nil, fmt.Errorf("missing required LightDNS fields")
+			return nil, errors.New("missing required LightDNS fields")
 		}
 		return New(&cfg)
 	})
@@ -49,7 +50,7 @@ func init() {
 
 func New(cfg *Config) (*LightDNS, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("LightDNS config is nil")
+		return nil, errors.New("LightDNS config is nil")
 	}
 	domain, err := dnsname.Normalize(cfg.Domain)
 	if err != nil {

--- a/updater/lightdns/lightdns.go
+++ b/updater/lightdns/lightdns.go
@@ -99,7 +99,6 @@ func (c *LightDNS) updateIP(ctx context.Context, ip string) error {
 			"key":    c.config.Key,
 			"myip":   ip,
 		}).Get("/update")
-
 	if err != nil {
 		return redact.Error(err, c.config.Key)
 	}

--- a/updater/lightdns/lightdns_test.go
+++ b/updater/lightdns/lightdns_test.go
@@ -22,9 +22,11 @@ func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) 
 }
 
 func TestUpdateIPRedactsKey(t *testing.T) {
+	t.Parallel()
 	key := "light+/key =secret"
 
 	t.Run("transport error", func(t *testing.T) {
+		t.Parallel()
 		lightDNS := mustNewLightDNS(t, &Config{Domain: "home.example.com", Key: key})
 		lightDNS.httpclient.SetRetryCount(0)
 		lightDNS.httpclient.SetTransport(roundTripFunc(func(_ *http.Request) (*http.Response, error) {
@@ -39,6 +41,7 @@ func TestUpdateIPRedactsKey(t *testing.T) {
 	})
 
 	t.Run("response body", func(t *testing.T) {
+		t.Parallel()
 		lightDNS := mustNewLightDNS(t, &Config{Domain: "home.example.com", Key: key})
 		lightDNS.httpclient.SetTransport(roundTripFunc(func(request *http.Request) (*http.Response, error) {
 			body := "invalid key " + key + " / " + url.QueryEscape(key)
@@ -59,6 +62,7 @@ func TestUpdateIPRedactsKey(t *testing.T) {
 }
 
 func TestUpdateIPRetriesTransientFailures(t *testing.T) {
+	t.Parallel()
 	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		switch attempts.Add(1) {
@@ -85,6 +89,7 @@ func TestUpdateIPRetriesTransientFailures(t *testing.T) {
 }
 
 func TestUpdateIPDoesNotRetryPermanentClientError(t *testing.T) {
+	t.Parallel()
 	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		attempts.Add(1)
@@ -105,6 +110,7 @@ func TestUpdateIPDoesNotRetryPermanentClientError(t *testing.T) {
 }
 
 func TestUpdateIPStopsRetriesWhenContextIsCanceled(t *testing.T) {
+	t.Parallel()
 	var attempts atomic.Int32
 	firstResponse := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -151,6 +157,7 @@ func TestUpdateIPStopsRetriesWhenContextIsCanceled(t *testing.T) {
 }
 
 func TestUpdateIPPropagatesContext(t *testing.T) {
+	t.Parallel()
 	type contextKey struct{}
 	key := contextKey{}
 	ctx := context.WithValue(context.Background(), key, "request-value")
@@ -173,6 +180,7 @@ func TestUpdateIPPropagatesContext(t *testing.T) {
 }
 
 func TestNewNormalizesAndValidatesDomain(t *testing.T) {
+	t.Parallel()
 	lightDNS := mustNewLightDNS(t, &Config{Domain: " Home.Example.COM. ", Key: "key"})
 	if lightDNS.config.Domain != "home.example.com" {
 		t.Fatalf("domain = %q, want %q", lightDNS.config.Domain, "home.example.com")
@@ -197,6 +205,7 @@ func TestNewNormalizesAndValidatesDomain(t *testing.T) {
 		"home/example.com",
 	} {
 		t.Run(domain, func(t *testing.T) {
+			t.Parallel()
 			if _, err := New(&Config{Domain: domain, Key: "key"}); err == nil {
 				t.Fatalf("expected domain %q to be rejected", domain)
 			}

--- a/updater/scaleway/scaleway_test.go
+++ b/updater/scaleway/scaleway_test.go
@@ -29,12 +29,14 @@ func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) 
 }
 
 func TestNewRejectsNilConfig(t *testing.T) {
+	t.Parallel()
 	if _, err := New(nil); err == nil {
 		t.Fatal("expected nil config to be rejected")
 	}
 }
 
 func TestDocumentedConfigKeysAreAccepted(t *testing.T) {
+	t.Parallel()
 	v := viper.New()
 	v.Set("updaters.use", "scaleway")
 	v.Set("updaters.scaleway.access_key", testAccessKey)
@@ -59,6 +61,7 @@ func TestDocumentedConfigKeysAreAccepted(t *testing.T) {
 }
 
 func TestNewNormalizesAndSplitsRecord(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		domain     string
@@ -93,6 +96,7 @@ func TestNewNormalizesAndSplitsRecord(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			scalewayUpdater, err := New(testConfig(tt.domain, tt.zone))
 			if err != nil {
 				t.Fatalf("New returned an error: %v", err)
@@ -111,6 +115,7 @@ func TestNewNormalizesAndSplitsRecord(t *testing.T) {
 }
 
 func TestNewRejectsRecordOutsideExplicitZone(t *testing.T) {
+	t.Parallel()
 	_, err := New(testConfig("home.example.net", "example.com"))
 	if err == nil {
 		t.Fatal("expected a record outside the explicit zone to be rejected")
@@ -118,6 +123,7 @@ func TestNewRejectsRecordOutsideExplicitZone(t *testing.T) {
 }
 
 func TestUpdateSetsEachAddressFamilyByIdentifier(t *testing.T) {
+	t.Parallel()
 	type capturedRequest struct {
 		method string
 		path   string
@@ -179,6 +185,7 @@ func TestUpdateSetsEachAddressFamilyByIdentifier(t *testing.T) {
 }
 
 func TestCurrentUsesNormalizedZoneAndRecord(t *testing.T) {
+	t.Parallel()
 	requests := make(chan *http.Request, 1)
 	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		requests <- request.Clone(request.Context())
@@ -218,6 +225,7 @@ func TestCurrentUsesNormalizedZoneAndRecord(t *testing.T) {
 }
 
 func TestCurrentRequiresDuplicateRecordsToAgree(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		records  string
@@ -257,6 +265,7 @@ func TestCurrentRequiresDuplicateRecordsToAgree(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			responseBody := `{"total_count":4,"records":` + tt.records + `}`
 			transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
 				return jsonResponse(request, responseBody), nil

--- a/version_command_test.go
+++ b/version_command_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestRunVersionCommandPrintsText(t *testing.T) {
-	t.Parallel()
 	oldVersion := version
 	version = "1.9.0"
 	t.Cleanup(func() {
@@ -38,7 +37,6 @@ func TestRunVersionCommandPrintsText(t *testing.T) {
 }
 
 func TestRunVersionCommandPrintsJSON(t *testing.T) {
-	t.Parallel()
 	oldVersion := version
 	version = "1.9.0"
 	t.Cleanup(func() {
@@ -113,7 +111,6 @@ func TestRunVersionCommandRejectsInvalidArguments(t *testing.T) {
 }
 
 func TestRunVersionCommandHelp(t *testing.T) {
-	t.Parallel()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	code := runVersionCommand([]string{"--help"}, &stdout, &stderr)
@@ -126,7 +123,6 @@ func TestRunVersionCommandHelp(t *testing.T) {
 }
 
 func TestRunVersionCommandReportsWriteErrors(t *testing.T) {
-	t.Parallel()
 	var stderr bytes.Buffer
 	code := runVersionCommand(nil, failingWriter{}, &stderr)
 	if code != 1 {

--- a/version_command_test.go
+++ b/version_command_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestRunVersionCommandPrintsText(t *testing.T) {
+	t.Parallel()
 	oldVersion := version
 	version = "1.9.0"
 	t.Cleanup(func() {
@@ -37,6 +38,7 @@ func TestRunVersionCommandPrintsText(t *testing.T) {
 }
 
 func TestRunVersionCommandPrintsJSON(t *testing.T) {
+	t.Parallel()
 	oldVersion := version
 	version = "1.9.0"
 	t.Cleanup(func() {
@@ -94,6 +96,7 @@ func TestRunVersionJSONIgnoresLoggingEnvironment(t *testing.T) {
 }
 
 func TestRunVersionCommandRejectsInvalidArguments(t *testing.T) {
+	t.Parallel()
 	for _, args := range [][]string{
 		{"version", "--unknown"},
 		{"version", "extra"},
@@ -110,6 +113,7 @@ func TestRunVersionCommandRejectsInvalidArguments(t *testing.T) {
 }
 
 func TestRunVersionCommandHelp(t *testing.T) {
+	t.Parallel()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	code := runVersionCommand([]string{"--help"}, &stdout, &stderr)
@@ -122,6 +126,7 @@ func TestRunVersionCommandHelp(t *testing.T) {
 }
 
 func TestRunVersionCommandReportsWriteErrors(t *testing.T) {
+	t.Parallel()
 	var stderr bytes.Buffer
 	code := runVersionCommand(nil, failingWriter{}, &stderr)
 	if code != 1 {


### PR DESCRIPTION
if you do not want a thing to change, i can remove that commit.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR modernizes the codebase with idiomatic Go patterns across 58 files, targeting Go 1.26. It is a pure refactoring with no intended behavior changes.

- **Error construction**: `fmt.Errorf("static string")` replaced with `errors.New(...)` throughout, and octal literals normalized to the `0o` prefix form.
- **Go 1.22–1.26 idioms**: `for i := range N` integer ranges, `strings.SplitSeq`, `slices.SortFunc`, `maps.Keys`, `sync.WaitGroup.Go`, and `new(false)` for pointer initialization.
- **Test quality**: `t.Parallel()` added to nearly every test, global mutable state (`SERVICES` map, `http.DefaultTransport`) replaced with per-instance state, and log-cleanup tests switched from `time.Local` to `time.UTC` for determinism.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are refactoring with no logic regressions found.

Every functional change is a clean substitution of newer stdlib APIs for older ones (slices/maps/iter, errors.New, range-over-int, sync.WaitGroup.Go, strings.SplitSeq) with equivalent semantics. The removal of the global SERVICES map reduces shared mutable state, making tests and production code safer. The only substantive deviation is that the error message listing supported IP services is now non-deterministically ordered, which is cosmetic.

**Files Needing Attention:** provider/ip_service/ip_service.go — the slices.Collect(maps.Keys(...)) call in the error message produces a non-deterministic list of supported services.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| provider/ip_service/ip_service.go | Removes global mutable SERVICES map, moves service URL map into a per-instance field and defaultServiceUrls() factory. Signature of New() changes from pointer to value receiver. Minor: supported-services list in error messages is now non-deterministically ordered. |
| logging.go | parseRotatedLogDate gains a location parameter instead of hardcoding time.Local; callers pass now.Location(), preserving production behaviour. Tests switch to time.UTC for determinism. |
| internal/redact/redact.go | sort.Slice replaced with slices.SortFunc using len(b)-len(a) comparator; descending-length sort order is preserved correctly. |
| notifier/discord/discord.go | Response-status handling collapsed into IsSuccess() first, then explicit 429 check. Semantically equivalent: 429 is not 2xx, so the order change has no effect on observable behaviour. |
| internal/dnsname/dnsname.go | strings.Split replaced with strings.SplitSeq (Go 1.24 iterator); for-range syntax updated accordingly. Logic unchanged. |
| internal/registry/registry_test.go | Uses sync.WaitGroup.Go (Go 1.25) to replace the wg.Add(1)/go func()/defer wg.Done() pattern. t.Parallel() added to all test functions. |
| updater/cloudflare/cloudflare_test.go | TestHTTPClientSupportsCustomDefaultTransport refactored to avoid mutating http.DefaultTransport; now sets client.Transport directly, eliminating a global-state hazard for parallel tests. |
| app/app.go | Removes two unused jobStatus constants (jobStatusIPChange, jobStatusUpdateSuccess). |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[New IpService] --> B{len names == 0?}
    B -- yes --> C[error: no IP service names provided]
    B -- no --> D[build ipService with defaultServiceUrls]
    D --> E{each name in urls?}
    E -- no --> F[error: unsupported IP service
maps.Keys order non-deterministic]
    E -- yes --> G[return ipService]

    H[getIP ctx client family] --> I{for each name}
    I --> J[lookup in ipService.urls]
    J --> K[HTTP request via resty client]
    K -- success --> L[return IP string]
    K -- failure --> M[append to failures
try next name]
    M --> I
    I -- exhausted --> N[return joined errors]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["refactor(logging): use time location fro..."](https://github.com/we11adam/uddns/commit/1ebc08678f4ab210500b9db52291289cb2c910d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47752817)</sub>

<!-- /greptile_comment -->